### PR TITLE
feat(detector): observabilidade - logar transicoes, gap e erros do loop (#36)

### DIFF
--- a/scriba/detector.py
+++ b/scriba/detector.py
@@ -14,6 +14,7 @@ mic estiver aberto: trocar de aba não a derruba.
 
 from __future__ import annotations
 
+import logging
 import re
 import time
 import winreg
@@ -23,6 +24,8 @@ from typing import Callable
 from .config import Detection
 
 _BASE = r"Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone"
+
+log = logging.getLogger("scriba.detector")
 
 
 class CallState(Enum):
@@ -275,7 +278,9 @@ class Detector:
         self.on_grace_cancel = on_grace_cancel  # mic voltou: era troca de device
         self.state = CallState.IDLE
         self._grace_deadline = 0.0
+        self._grace_since = 0.0  # entrada no GRACE (para medir o gap do resume)
         self._recording_since = 0.0
+        self._last_exc_log = 0.0  # rate-limit do log de exceções do loop
 
     def _sense_call(self) -> str | None:
         """Quem está em call agora: app desktop, ou navegador com call confirmada."""
@@ -297,6 +302,7 @@ class Detector:
 
     def poll_once(self) -> None:
         now = time.monotonic()
+        prev_app = self.current_app
         app = self._sense_call()
         in_use = app is not None
         if app:
@@ -310,20 +316,45 @@ class Detector:
         elif self.state is CallState.RECORDING:
             if not in_use:
                 self.state = CallState.GRACE
+                self._grace_since = now
                 self._grace_deadline = now + self.cfg.grace_seconds
+                log.info(
+                    "mic liberado (%s) - tolerância de %.0fs",
+                    self.current_app, self.cfg.grace_seconds,
+                )
                 if self.on_grace:
                     self.on_grace()
-            elif now - self._recording_since > self.cfg.max_call_hours * 3600:
-                # parada de segurança: encerra; se o mic seguir em uso, um novo
-                # segmento começa no próximo poll
-                self.state = CallState.IDLE
-                self.on_call_ended()
+            else:
+                # mic ainda em uso: vigiar troca de app monitorado (Teams -> Zoom).
+                # Em #34 isso vira SPLIT; aqui é só o WARN que antecipa o caso.
+                if prev_app and app != prev_app:
+                    log.warning(
+                        "troca de app monitorado durante a call: %s -> %s", prev_app, app
+                    )
+                if now - self._recording_since > self.cfg.max_call_hours * 3600:
+                    # parada de segurança: encerra; se o mic seguir em uso, um novo
+                    # segmento começa no próximo poll
+                    log.info(
+                        "call encerrada (limite de segurança de %gh)", self.cfg.max_call_hours
+                    )
+                    self.state = CallState.IDLE
+                    self.on_call_ended()
         elif self.state is CallState.GRACE:
             if in_use:
+                gap = now - self._grace_since
+                if prev_app and app != prev_app:
+                    # mic voltou em OUTRO app monitorado (Teams -> Zoom): hoje
+                    # emenda na mesma gravação (a fusão do incidente); #34 fará o split
+                    log.warning(
+                        "mic voltou em app diferente após %.1fs: %s -> %s", gap, prev_app, app
+                    )
+                else:
+                    log.info("mic voltou após %.1fs - mesma call", gap)
                 self.state = CallState.RECORDING
                 if self.on_grace_cancel:
                     self.on_grace_cancel()
             elif now >= self._grace_deadline:
+                log.info("call encerrada (mic livre > %.0fs)", self.cfg.grace_seconds)
                 self.state = CallState.IDLE
                 self.on_call_ended()
                 self.current_app = None
@@ -335,7 +366,12 @@ class Detector:
             try:
                 self.poll_once()
             except Exception:
-                pass  # nunca derruba o loop; tenta de novo no próximo poll
+                # nunca derruba o loop; mas não engole mudo: loga no máximo 1x/min
+                # (se o registro do Windows falhar em loop, o log não inunda)
+                now = time.monotonic()
+                if now - self._last_exc_log >= 60:
+                    self._last_exc_log = now
+                    log.exception("falha no poll do detector")
             stop_event.wait(self.cfg.poll_seconds)
         if self.state is not CallState.IDLE:
             self.state = CallState.IDLE
@@ -346,6 +382,15 @@ class Detector:
 def debug_loop() -> int:
     """`scriba detect`: imprime as transições de estado para teste manual."""
     from .config import load
+
+    # espelha os logs INFO/WARN do detector (GRACE, resume com o gap medido,
+    # encerramento com o motivo, troca de app) no console
+    root = logging.getLogger()
+    if not root.handlers:
+        h = logging.StreamHandler()
+        h.setFormatter(logging.Formatter("[%(asctime)s] %(message)s", datefmt="%H:%M:%S"))
+        root.addHandler(h)
+        root.setLevel(logging.INFO)
 
     cfg = load().detection
     pats = patterns_from(cfg)
@@ -371,14 +416,10 @@ def debug_loop() -> int:
         on_call_started=lambda: stamp(">>> CALL INICIADA - a gravação começaria agora"),
         on_call_ended=lambda: stamp("<<< CALL ENCERRADA - a transcrição começaria agora"),
     )
-    last = det.state
     pending: str | None = None  # navegador com mic aberto, call ainda não confirmada
     try:
         while True:
             det.poll_once()
-            if det.state is not last:
-                stamp(f"estado: {last.value} -> {det.state.value} ({det.current_app or '-'})")
-                last = det.state
             if bpats and det.state is CallState.IDLE:
                 b = active_browser(bpats)
                 if b != pending:

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,12 +1,15 @@
-"""Testes de scriba.detector._clean_meeting_title (nome da reunião pelo título da janela)."""
+"""Testes de scriba.detector: máquina de estados do Detector e _clean_meeting_title."""
 
 import sys
 import unittest
+import unittest.mock as mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scriba.detector import _clean_meeting_title  # noqa: E402
+from scriba import detector  # noqa: E402
+from scriba.config import Detection  # noqa: E402
+from scriba.detector import CallState, Detector, _clean_meeting_title  # noqa: E402
 
 
 class CleanMeetingTitleTests(unittest.TestCase):
@@ -37,6 +40,157 @@ class CleanMeetingTitleTests(unittest.TestCase):
         self.assertEqual(_clean_meeting_title(""), "")
         self.assertEqual(_clean_meeting_title("   "), "")
         self.assertEqual(_clean_meeting_title("Zoom"), "")
+
+
+class _Clock:
+    """Relógio monotônico controlado (substitui time.monotonic nos testes)."""
+
+    def __init__(self, start: float = 1000.0):
+        self.t = start
+
+    def monotonic(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class _StopAfter:
+    """stop_event falso: deixa Detector.run fazer exatamente n iterações do loop."""
+
+    def __init__(self, n: int):
+        self.n = n
+        self.waits = 0
+
+    def is_set(self) -> bool:
+        return self.waits >= self.n
+
+    def wait(self, _timeout: float) -> None:
+        self.waits += 1
+
+
+class DetectorStateMachineTests(unittest.TestCase):
+    """Máquina de estados + observabilidade (#36). O registro do Windows é
+    substituído por um fake de _sense_call e o tempo por um _Clock."""
+
+    def setUp(self):
+        self.clock = _Clock()
+        p = mock.patch.object(detector.time, "monotonic", self.clock.monotonic)
+        p.start()
+        self.addCleanup(p.stop)
+        self.events: list[str] = []
+        self.mic: str | None = None  # app com o mic aberto agora, ou None
+
+    def _make(self, **over) -> Detector:
+        params = dict(grace_seconds=8.0, poll_seconds=2.0, max_call_hours=4.0)
+        params.update(over)
+        det = Detector(
+            Detection(**params),
+            on_call_started=lambda: self.events.append("started"),
+            on_call_ended=lambda: self.events.append("ended"),
+            on_grace=lambda: self.events.append("grace"),
+            on_grace_cancel=lambda: self.events.append("resume"),
+        )
+        det._sense_call = lambda: self.mic  # controla quem está em call
+        self.det = det
+        return det
+
+    def _poll(self, mic: str | None, advance: float = 0.0) -> None:
+        if advance:
+            self.clock.advance(advance)
+        self.mic = mic
+        self.det.poll_once()
+
+    # -------- transições básicas --------
+
+    def test_idle_para_recording(self):
+        self._make()
+        self._poll("Teams")
+        self.assertIs(self.det.state, CallState.RECORDING)
+        self.assertEqual(self.events, ["started"])
+
+    def test_grace_e_encerramento_por_timeout(self):
+        self._make()
+        self._poll("Teams")
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll(None)  # mic liberado -> GRACE
+        self.assertIs(self.det.state, CallState.GRACE)
+        self.assertIn("mic liberado (Teams) - tolerância de 8s", "\n".join(cm.output))
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll(None, advance=9.0)  # passou o grace inteiro
+        self.assertIs(self.det.state, CallState.IDLE)
+        self.assertIn("call encerrada (mic livre > 8s)", "\n".join(cm.output))
+        self.assertEqual(self.events, ["started", "grace", "ended"])
+
+    # -------- resume e o gap medido (#36) --------
+
+    def test_resume_dentro_do_grace_loga_gap(self):
+        self._make()
+        self._poll("Teams")
+        self._poll(None)  # -> GRACE
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll("Teams", advance=4.0)  # mic volta em 4s (mesma call)
+        self.assertIs(self.det.state, CallState.RECORDING)
+        self.assertIn("mic voltou após 4.0s - mesma call", "\n".join(cm.output))
+        self.assertIn("resume", self.events)
+
+    def test_resume_em_app_diferente_loga_warning(self):
+        # Teams libera o mic e o Zoom pega dentro do grace: hoje emenda na mesma
+        # gravação (a fusão do incidente 2026-07-02); o log tem de deixar isso VISÍVEL.
+        self._make()
+        self._poll("Teams")
+        self._poll(None)  # -> GRACE
+        with self.assertLogs("scriba.detector", "WARNING") as cm:
+            self._poll("Zoom", advance=3.0)
+        self.assertIs(self.det.state, CallState.RECORDING)
+        out = "\n".join(cm.output)
+        self.assertIn("app diferente", out)
+        self.assertIn("Teams -> Zoom", out)
+
+    # -------- troca de app sem grace (Teams -> Zoom direto) --------
+
+    def test_troca_de_app_durante_recording_loga_warning(self):
+        self._make()
+        self._poll("Teams")  # RECORDING
+        self._poll("Teams")  # segue igual, sem aviso
+        with self.assertLogs("scriba.detector", "WARNING") as cm:
+            self._poll("Zoom")  # troca sem passar pelo grace
+        self.assertIs(self.det.state, CallState.RECORDING)
+        self.assertIn(
+            "troca de app monitorado durante a call: Teams -> Zoom", "\n".join(cm.output)
+        )
+
+    # -------- parada de segurança por max_call_hours --------
+
+    def test_max_call_hours_encerra_e_loga(self):
+        self._make(max_call_hours=1.0)
+        self._poll("Teams")
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll("Teams", advance=3601.0)  # > 1h com o mic ainda aberto
+        self.assertIs(self.det.state, CallState.IDLE)
+        self.assertIn("limite de segurança de 1h", "\n".join(cm.output))
+        self.assertEqual(self.events, ["started", "ended"])
+
+    # -------- rate-limit do log de exceções do loop --------
+
+    def test_excecao_no_poll_logada_uma_vez_por_minuto(self):
+        det = self._make()
+        det._sense_call = mock.Mock(side_effect=RuntimeError("registro falhou"))
+        with self.assertLogs("scriba.detector", "ERROR") as cm:
+            det.run(_StopAfter(2))  # 2 polls no MESMO instante
+        falhas = [line for line in cm.output if "falha no poll" in line]
+        self.assertEqual(len(falhas), 1)  # o segundo poll (< 60s) é suprimido
+
+    def test_excecao_no_poll_volta_a_logar_apos_60s(self):
+        det = self._make()
+        det._sense_call = mock.Mock(side_effect=RuntimeError("registro falhou"))
+        with self.assertLogs("scriba.detector", "ERROR") as cm:
+            det.run(_StopAfter(1))
+        self.assertEqual(len(cm.output), 1)
+        self.clock.advance(61.0)
+        with self.assertLogs("scriba.detector", "ERROR") as cm:
+            det.run(_StopAfter(1))  # já passou 1 min -> loga de novo
+        self.assertEqual(len(cm.output), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fecha #36 (primeira fatia do epico de fusao de calls #34-#38).

## Contexto
No incidente de 2026-07-02 (duas calls fundidas, #34) o `scriba.log` pula de `gravacao iniciada` direto para `gravacao encerrada`, sem NENHUM evento no meio - impossivel saber qual caminho levou a fusao. Alem disso o loop do detector engolia toda excecao (`except Exception: pass`), entao uma falha em loop na leitura do registro pararia a deteccao mudo.

## O que muda
- **Logger `scriba.detector`** (o modulo nao logava nada).
- **INFO** nas transicoes: entrada em GRACE, resume **com o gap medido** (`mic voltou apos 4.2s - mesma call`), encerramento com o motivo (`mic livre > 8s` / `limite de seguranca de 4h`).
- **WARN** nos casos anomalos: troca de app monitorado durante a call e resume dentro do grace **em app diferente** (a fusao Teams->Zoom do incidente, agora visivel).
- O `except` do loop passa a **logar 1x/min** em vez de engolir mudo.
- `scribadev detect` espelha os eventos no console.

**Zero mudanca de comportamento** - as transicoes de estado sao identicas; so adiciona observabilidade. Os gaps reais logados servem para calibrar o `split_gap_seconds` de #34 antes de ligar a divisao automatica.

## Fora de escopo (dependem de #34)
WARN de "ciclo invisivel de sessao" e o log do split: ambos precisam ler o `LastUsedTimeStart`, nucleo da #34.

## Testes
Primeira cobertura da maquina de estados do `Detector` (so `_clean_meeting_title` tinha teste): 8 casos novos com relogio e registro fakeados - GRACE + resume com gap, encerramento por timeout, resume em app diferente, troca de app sem grace, `max_call_hours`, e o rate-limit do log de excecao (suprime < 60s, volta a logar apos). `test_detector` 15/15 verde.