### PR TITLE
fix(detector): dividir calls consecutivas pelo ciclo da sessao de mic (#34)

### DIFF
--- a/scriba/config.py
+++ b/scriba/config.py
@@ -33,6 +33,11 @@ browsers = "chrome, msedge, firefox, brave, opera, vivaldi"
 browser_titles = "Meet, Microsoft Teams, Zoom, Webex"
 poll_seconds = 2
 grace_seconds = 8        # mic liberado por até X s ainda conta como a mesma call
+# Sair de uma call e entrar em outra em seguida: se o mic REABRE após um gap de pelo
+# menos split_gap_seconds, o ScribaDev encerra a gravação e começa outra (duas notas).
+# 0 = nunca dividir sozinho (comportamento antigo). Só vale para gaps entre ~poll_seconds
+# e grace_seconds; acima de grace_seconds a call já divide pelo timeout do GRACE.
+split_gap_seconds = 3
 min_call_seconds = 30    # gravações mais curtas são descartadas (pré-join, teste de mic)
 max_call_hours = 4       # parada de segurança
 auto_record = true       # gravar sozinho ao detectar a call; desligado, a pílula espera o ⏺
@@ -123,6 +128,9 @@ class Detection:
     browser_titles: str = "Meet, Microsoft Teams, Zoom, Webex"
     poll_seconds: float = 2.0
     grace_seconds: float = 8.0
+    # Gap mínimo (mic reabrindo) para dividir duas calls consecutivas; 0 = nunca.
+    # Só age entre ~poll_seconds e grace_seconds (ver DEFAULT_CONFIG e #34).
+    split_gap_seconds: float = 3.0
     min_call_seconds: float = 30.0
     max_call_hours: float = 4.0
     auto_record: bool = True
@@ -297,6 +305,7 @@ browsers = {_s(d.browsers)}
 browser_titles = {_s(d.browser_titles)}
 poll_seconds = {_n(d.poll_seconds)}
 grace_seconds = {_n(d.grace_seconds)}        # mic liberado por até X s ainda conta como a mesma call
+split_gap_seconds = {_n(d.split_gap_seconds)}    # gap p/ dividir calls consecutivas (0 = nunca); ver #34
 min_call_seconds = {_n(d.min_call_seconds)}    # gravações mais curtas são descartadas (pré-join, teste de mic)
 max_call_hours = {_n(d.max_call_hours)}       # parada de segurança
 auto_record = {_b(d.auto_record)}       # gravar sozinho ao detectar a call; desligado, a pílula espera o ⏺

--- a/scriba/detector.py
+++ b/scriba/detector.py
@@ -65,7 +65,12 @@ def friendly_name(pattern_or_key: str) -> str:
 
 
 def _iter_mic_keys():
-    """(nome_da_subchave, LastUsedTimeStop) para cada app rastreado pelo Windows."""
+    """(subchave, LastUsedTimeStart, LastUsedTimeStop) para cada app rastreado.
+
+    Os dois tempos são FILETIME (100 ns desde 1601). LastUsedTimeStop == 0 enquanto
+    o app está com o mic aberto. LastUsedTimeStart é reescrito toda vez que o app
+    REABRE o mic — é o sinal de fronteira entre duas calls consecutivas (#34).
+    """
     for base in (_BASE, _BASE + r"\NonPackaged"):
         try:
             root = winreg.OpenKey(winreg.HKEY_CURRENT_USER, base)
@@ -84,14 +89,30 @@ def _iter_mic_keys():
                 try:
                     with winreg.OpenKey(root, sub) as k:
                         stop, _ = winreg.QueryValueEx(k, "LastUsedTimeStop")
+                        try:
+                            start, _ = winreg.QueryValueEx(k, "LastUsedTimeStart")
+                        except OSError:
+                            start = 0  # chave sem o valor (raro): trata como desconhecido
                 except OSError:
                     continue
-                yield sub, stop
+                yield sub, start, stop
+
+
+def active_sessions(patterns: list[str]) -> dict[str, tuple[int, int]]:
+    """{subchave: (LastUsedTimeStart, LastUsedTimeStop)} das subchaves que casam
+    algum pattern (substring, como active_app). É a base para o detector rastrear
+    a sessão de mic que sustenta a call e medir o gap por FILETIME (#34)."""
+    out: dict[str, tuple[int, int]] = {}
+    for sub, start, stop in _iter_mic_keys():
+        low = sub.lower()
+        if any(p in low for p in patterns):
+            out[sub] = (start, stop)
+    return out
 
 
 def active_app(patterns: list[str]) -> str | None:
     """Nome amigável do app monitorado que está com o mic aberto agora, ou None."""
-    for sub, stop in _iter_mic_keys():
+    for sub, _start, stop in _iter_mic_keys():
         if stop != 0:
             continue
         low = sub.lower()
@@ -104,7 +125,7 @@ def active_app(patterns: list[str]) -> str | None:
 def app_key_status(patterns: list[str]) -> dict[str, bool]:
     """{nome amigável: já existe chave no registro?} — para o doctor."""
     found = {friendly_name(p): False for p in patterns}
-    for sub, _stop in _iter_mic_keys():
+    for sub, _start, _stop in _iter_mic_keys():
         low = sub.lower()
         for p in patterns:
             if p in low:
@@ -123,7 +144,7 @@ def active_browser(browser_pats: list[str]) -> str | None:
     Match exato do executável: "msedge" não pode casar o msedgewebview2.exe
     que apps desktop (Teams, Outlook) embutem.
     """
-    for sub, stop in _iter_mic_keys():
+    for sub, _start, stop in _iter_mic_keys():
         if stop != 0:
             continue
         base = _key_basename(sub)
@@ -136,7 +157,7 @@ def active_browser(browser_pats: list[str]) -> str | None:
 def browser_key_status(browser_pats: list[str]) -> dict[str, bool]:
     """{navegador: já existe chave de mic no registro?} — para o doctor."""
     found = {p: False for p in browser_pats}
-    for sub, _stop in _iter_mic_keys():
+    for sub, _start, _stop in _iter_mic_keys():
         base = _key_basename(sub)
         for p in browser_pats:
             if base == p + ".exe":
@@ -259,7 +280,7 @@ class Detector:
     def __init__(
         self,
         cfg: Detection,
-        on_call_started: Callable[[], None],
+        on_call_started: Callable[..., None],  # aceita probe=bool (split pula a sonda)
         on_call_ended: Callable[[], None],
         on_grace: Callable[[], None] | None = None,
         on_grace_cancel: Callable[[], None] | None = None,
@@ -281,43 +302,74 @@ class Detector:
         self._grace_since = 0.0  # entrada no GRACE (para medir o gap do resume)
         self._recording_since = 0.0
         self._last_exc_log = 0.0  # rate-limit do log de exceções do loop
+        # sessão de mic que sustenta a call rastreada (para dividir calls seguidas, #34)
+        self._session_sub: str | None = None   # subchave do registro
+        self._session_start = 0                 # LastUsedTimeStart (FILETIME) no início
+        self._session_stop = 0                  # LastUsedTimeStop guardado ao entrar no GRACE
 
-    def _sense_call(self) -> str | None:
-        """Quem está em call agora: app desktop, ou navegador com call confirmada."""
-        app = active_app(self.patterns)
-        if app:
-            return app
+    def _mic_sessions(self) -> dict[str, tuple[int, int]]:
+        """{subchave: (start, stop)} das sessões de mic de apps e navegadores
+        monitorados — a matéria-prima para detectar a call e rastrear sua sessão."""
+        sessions = active_sessions(self.patterns)  # apps desktop (substring)
+        if self.browser_pats:  # navegadores: match exato do exe (não pega webview embutido)
+            for sub, start, stop in _iter_mic_keys():
+                base = _key_basename(sub)
+                if any(base == p + ".exe" for p in self.browser_pats):
+                    sessions[sub] = (start, stop)
+        return sessions
+
+    def _sense(self, sessions: dict[str, tuple[int, int]]) -> tuple[str, str, int] | None:
+        """(nome amigável, subchave, LastUsedTimeStart) da call ativa agora, ou None.
+
+        App desktop tem prioridade; senão, navegador com reunião confirmada por
+        título (uma vez confirmada, o mic aberto basta — trocar de aba não derruba).
+        """
+        for sub, (start, stop) in sessions.items():
+            if stop != 0:
+                continue
+            low = sub.lower()
+            for p in self.patterns:
+                if p in low:
+                    return friendly_name(sub if len(p) < 6 else p), sub, start
         if not self.browser_pats:
             return None
-        browser = active_browser(self.browser_pats)
-        if browser is None:
-            return None
-        if self._web_call:
-            return self.current_app or browser.capitalize()
-        svc = browser_call_service(browser, self.title_pats)
-        if svc:
-            self._web_call = True
-            return svc
-        return None  # mic aberto no navegador, mas nenhum título de reunião (ainda)
+        for sub, (start, stop) in sessions.items():
+            if stop != 0:
+                continue
+            base = _key_basename(sub)
+            for p in self.browser_pats:
+                if base != p + ".exe":
+                    continue
+                if self._web_call:
+                    return (self.current_app or p.capitalize()), sub, start
+                svc = browser_call_service(p, self.title_pats)
+                if svc:
+                    self._web_call = True
+                    return svc, sub, start
+                return None  # mic no navegador, mas nenhum título de reunião ainda
+        return None
 
     def poll_once(self) -> None:
         now = time.monotonic()
-        prev_app = self.current_app
-        app = self._sense_call()
-        in_use = app is not None
-        if app:
-            self.current_app = app
+        sessions = self._mic_sessions()
+        sense = self._sense(sessions)
+        in_use = sense is not None
+        prev_app = self.current_app  # antes da atualização, para os logs de troca
+        if sense:
+            self.current_app = sense[0]
 
         if self.state is CallState.IDLE:
             if in_use:
-                self.state = CallState.RECORDING
-                self._recording_since = now
-                self.on_call_started()
+                self._begin(now, sense)
+
         elif self.state is CallState.RECORDING:
             if not in_use:
+                # mic liberado -> GRACE. Guarda o LastUsedTimeStop EXATO da subchave
+                # rastreada: o instante em que o app fechou o mic, sem depender do poll.
                 self.state = CallState.GRACE
                 self._grace_since = now
                 self._grace_deadline = now + self.cfg.grace_seconds
+                self._session_stop = sessions.get(self._session_sub or "", (0, 0))[1]
                 log.info(
                     "mic liberado (%s) - tolerância de %.0fs",
                     self.current_app, self.cfg.grace_seconds,
@@ -325,40 +377,124 @@ class Detector:
                 if self.on_grace:
                     self.on_grace()
             else:
-                # mic ainda em uso: vigiar troca de app monitorado (Teams -> Zoom).
-                # Em #34 isso vira SPLIT; aqui é só o WARN que antecipa o caso.
-                if prev_app and app != prev_app:
-                    log.warning(
-                        "troca de app monitorado durante a call: %s -> %s", prev_app, app
-                    )
-                if now - self._recording_since > self.cfg.max_call_hours * 3600:
-                    # parada de segurança: encerra; se o mic seguir em uso, um novo
-                    # segmento começa no próximo poll
-                    log.info(
-                        "call encerrada (limite de segurança de %gh)", self.cfg.max_call_hours
-                    )
-                    self.state = CallState.IDLE
-                    self.on_call_ended()
+                self._watch_recording(now, sense, sessions, prev_app)
+
         elif self.state is CallState.GRACE:
             if in_use:
-                gap = now - self._grace_since
-                if prev_app and app != prev_app:
-                    # mic voltou em OUTRO app monitorado (Teams -> Zoom): hoje
-                    # emenda na mesma gravação (a fusão do incidente); #34 fará o split
-                    log.warning(
-                        "mic voltou em app diferente após %.1fs: %s -> %s", gap, prev_app, app
-                    )
-                else:
-                    log.info("mic voltou após %.1fs - mesma call", gap)
-                self.state = CallState.RECORDING
-                if self.on_grace_cancel:
-                    self.on_grace_cancel()
+                self._resume_or_split(now, sense, sessions, prev_app)
             elif now >= self._grace_deadline:
                 log.info("call encerrada (mic livre > %.0fs)", self.cfg.grace_seconds)
-                self.state = CallState.IDLE
-                self.on_call_ended()
-                self.current_app = None
-                self._web_call = False
+                self._end_call()
+
+    def _watch_recording(
+        self, now: float, sense: tuple[str, str, int],
+        sessions: dict[str, tuple[int, int]], prev_app: str | None,
+    ) -> None:
+        """RECORDING com o mic ainda em uso: detecta nova call sem passar pelo GRACE
+        (Teams->Zoom sem gap) e o ciclo de sessão invisível (mic reabriu < poll)."""
+        _name, sub, start = sense
+        tracked = sessions.get(self._session_sub or "")
+        if self._session_sub and sub != self._session_sub:
+            # a call agora é sustentada por OUTRA subchave monitorada
+            if tracked is not None and tracked[1] != 0 and self.cfg.split_gap_seconds > 0:
+                # a rastreada fechou o mic e outra assumiu -> Teams->Zoom sem gap
+                log.info(
+                    "app trocou (%s livre, %s em uso) - dividindo a gravação",
+                    prev_app, sense[0],
+                )
+                self._split(now, sessions)
+                return
+            log.warning("troca de app monitorado durante a call: %s -> %s", prev_app, sense[0])
+            self._session_sub, self._session_start = sub, start
+        elif tracked is not None and tracked[1] == 0 and start != self._session_start:
+            # MESMA subchave, mas o start foi reescrito: o mic reabriu entre dois
+            # polls (gap < poll). Indistinguível de troca de device -> v1 NÃO divide;
+            # o sinal de título (#35) desempata. Loga e atualiza o rastreamento.
+            log.warning(
+                "ciclo de sessão invisível em %s (start mudou) - nao divido na v1",
+                self.current_app,
+            )
+            self._session_start = start
+        elif now - self._recording_since > self.cfg.max_call_hours * 3600:
+            log.info("call encerrada (limite de segurança de %gh)", self.cfg.max_call_hours)
+            self._end_call()
+
+    def _resume_or_split(
+        self, now: float, sense: tuple[str, str, int],
+        sessions: dict[str, tuple[int, int]], prev_app: str | None,
+    ) -> None:
+        """GRACE + mic em uso de novo: emendar na mesma gravação (troca de fone) ou
+        dividir (call nova). A decisão usa a subchave e o gap por FILETIME (#34, item 4)."""
+        name, sub, start = sense
+        gap_wall = now - self._grace_since  # fallback: relógio de parede (o gap de #36)
+        split_on = self.cfg.split_gap_seconds > 0
+
+        if self._session_sub and sub != self._session_sub:
+            # mic voltou em OUTRA subchave monitorada -> nova call
+            if split_on:
+                log.info("mic voltou em app diferente (%s -> %s) - dividindo a gravação", prev_app, name)
+                self._split(now, sessions)
+                return
+            log.warning(
+                "mic voltou em app diferente após %.1fs: %s -> %s (split desligado)",
+                gap_wall, prev_app, name,
+            )
+        else:
+            # mesma subchave: gap por FILETIME (cai no relógio de parede se falhar a leitura)
+            gap = self._filetime_gap(start, self._session_stop)
+            gap = gap_wall if gap is None else gap
+            if split_on and gap >= self.cfg.split_gap_seconds:
+                log.info(
+                    "gap de %.1fs >= split_gap_seconds=%g - dividindo a gravação",
+                    gap, self.cfg.split_gap_seconds,
+                )
+                self._split(now, sessions)
+                return
+            log.info("mic voltou após %.1fs - mesma call", gap)
+
+        # emenda (resume): atualiza o rastreamento e volta a RECORDING
+        self.state = CallState.RECORDING
+        self._session_sub, self._session_start = sub, start
+        if self.on_grace_cancel:
+            self.on_grace_cancel()
+
+    def _begin(self, now: float, sense: tuple[str, str, int], probe: bool = True) -> None:
+        """IDLE -> RECORDING: começa a rastrear a sessão de mic que sustenta a call."""
+        name, sub, start = sense
+        self.current_app = name
+        self.state = CallState.RECORDING
+        self._recording_since = now
+        self._session_sub, self._session_start = sub, start
+        self.on_call_started(probe=probe)
+
+    def _end_call(self) -> None:
+        """Encerra a call e volta a IDLE (timeout do GRACE ou parada de segurança)."""
+        self.state = CallState.IDLE
+        self.on_call_ended()
+        self.current_app = None
+        self._web_call = False
+        self._session_sub = None
+
+    def _split(self, now: float, sessions: dict[str, tuple[int, int]]) -> None:
+        """Encerra a call atual e, se o mic segue em uso, começa OUTRA na MESMA
+        iteração — duas pastas, duas notas. A parte 1 segue o fluxo normal (fila)."""
+        self.on_call_ended()
+        self.state = CallState.IDLE
+        self.current_app = None
+        self._web_call = False       # call web nova reconfirma pelo título
+        self._session_sub = None
+        sense = self._sense(sessions)
+        if sense:
+            # sonda de áudio dispensada: os dispositivos funcionavam há < poll_seconds
+            self._begin(now, sense, probe=False)
+
+    @staticmethod
+    def _filetime_gap(start_new: int, stop_old: int) -> float | None:
+        """Gap em segundos entre o fim de uma sessão de mic e o início da próxima,
+        por FILETIME (100 ns desde 1601). None se algum dos tempos é desconhecido."""
+        if not start_new or not stop_old:
+            return None
+        return (start_new - stop_old) / 1e7
 
     def run(self, stop_event) -> None:
         """Loop de detecção (roda em thread própria)."""
@@ -376,6 +512,7 @@ class Detector:
         if self.state is not CallState.IDLE:
             self.state = CallState.IDLE
             self._web_call = False
+            self._session_sub = None
             self.on_call_ended()
 
 
@@ -413,7 +550,7 @@ def debug_loop() -> int:
 
     det = Detector(
         cfg,
-        on_call_started=lambda: stamp(">>> CALL INICIADA - a gravação começaria agora"),
+        on_call_started=lambda *a, **k: stamp(">>> CALL INICIADA - a gravação começaria agora"),
         on_call_ended=lambda: stamp("<<< CALL ENCERRADA - a transcrição começaria agora"),
     )
     pending: str | None = None  # navegador com mic aberto, call ainda não confirmada

--- a/scriba/main.py
+++ b/scriba/main.py
@@ -169,11 +169,11 @@ class ScribaApp:
 
     # --------------------------------------------------------------- call --
 
-    def _on_call_started(self) -> None:
+    def _on_call_started(self, probe: bool = True) -> None:
         self.call_active = True
         self.call_started_at = time.monotonic()
         if self.cfg.detection.auto_record:
-            self.start_recording("auto")
+            self.start_recording("auto", probe=probe)
         else:
             self.ui(self._show_pill_idle)
 
@@ -194,10 +194,13 @@ class ScribaApp:
 
     # ----------------------------------------------------------- gravação --
 
-    def start_recording(self, source: str = "auto") -> None:
+    def start_recording(self, source: str = "auto", probe: bool = True) -> None:
         # pré-checagem em subprocesso: se o PortAudio estiver num estado que
-        # aborta (assert de troca de dispositivo), morre a sonda — não o app
-        if util.run_audio_probe() is None:
+        # aborta (assert de troca de dispositivo), morre a sonda — não o app.
+        # probe=False no split de calls consecutivas (#34): os dispositivos
+        # funcionavam há < poll_seconds e a sonda pode custar segundos que viram
+        # buraco no início da call 2. Se Recording() falhar, o try/except cobre.
+        if probe and util.run_audio_probe() is None:
             log.error("dispositivos de áudio indisponíveis — gravação não iniciada (%s)", source)
             self._toast("ScribaDev: áudio indisponível", "Não consegui acessar microfone/loopback agora.")
             return

--- a/scriba/settings_ui.py
+++ b/scriba/settings_ui.py
@@ -899,6 +899,21 @@ class SettingsWindow:
         for name in _DETECTION_PRESETS:
             ModernButton(preset_row, name, lambda n=name: self._apply_detection_preset(n)).pack(side="left", padx=3)
 
+        consec = self._group(tab, "Calls consecutivas")
+        split_row = tk.Frame(consec, bg=_BG)
+        split_row.pack(fill="x", pady=6)
+        tk.Label(split_row, text="Dividir quando o mic reabre após (gap)", bg=_BG,
+                 fg=PALETTE["text"], font=FONT).pack(side="left")
+        self.split_gap_var = tk.IntVar(value=3)
+        Stepper(split_row, self.split_gap_var, step=1, lo=0, hi=30, suffix=" s").pack(side="right")
+        tk.Label(
+            consec,
+            text="Sair de uma call e entrar em outra em seguida vira duas notas, não uma.\n"
+            "0 = nunca dividir sozinho. Só vale para gaps entre ~2 s (poll) e a tolerância\n"
+            "(grace); acima disso a call já é dividida.",
+            bg=_BG, fg=PALETTE["muted"], font=("Segoe UI", 8), justify="left",
+        ).pack(anchor="w", pady=(2, 0))
+
     def _labeled_entry(self, parent, label: str, var: tk.StringVar, hint: str, *,
                        secret: bool = False, placeholder: str | None = None) -> None:
         tk.Label(parent, text=label, bg=_BG, fg=PALETTE["text"], font=FONT_BOLD).pack(anchor="w", pady=(6, 3))
@@ -1210,6 +1225,7 @@ class SettingsWindow:
         self.min_speakers_var.set(int(getattr(cfg.diarization, "min_speakers", 0)))
         self.hotkey_var.set(cfg.ui.hotkey)
         self.min_secs_var.set(int(cfg.detection.min_call_seconds))
+        self.split_gap_var.set(int(cfg.detection.split_gap_seconds))
         self.apps_var.set(cfg.detection.apps)
         self.browsers_var.set(cfg.detection.browsers)
         self.titles_var.set(cfg.detection.browser_titles)
@@ -1319,6 +1335,7 @@ class SettingsWindow:
                 browsers=self.browsers_var.get().strip(),
                 browser_titles=self.titles_var.get().strip(),
                 min_call_seconds=float(self.min_secs_var.get()),
+                split_gap_seconds=float(self.split_gap_var.get()),
                 auto_record=self.auto_record_var.get(),
             ),
             diarization=dataclasses.replace(

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -11,6 +11,12 @@ from scriba import detector  # noqa: E402
 from scriba.config import Detection  # noqa: E402
 from scriba.detector import CallState, Detector, _clean_meeting_title  # noqa: E402
 
+# FILETIME é contado em intervalos de 100 ns desde 1601.
+_FT = 10_000_000                     # 1 segundo
+_BASE = 134_000_000_000_000_000      # instante-base arbitrário (~2025)
+TEAMS = "MSTeams_8wekyb3d8bbwe"       # casa o pattern "teams"
+ZOOM = "Zoom.exe"                     # casa o pattern "zoom"
+
 
 class CleanMeetingTitleTests(unittest.TestCase):
     def test_teams_chat(self):
@@ -70,112 +76,198 @@ class _StopAfter:
 
 
 class DetectorStateMachineTests(unittest.TestCase):
-    """Máquina de estados + observabilidade (#36). O registro do Windows é
-    substituído por um fake de _sense_call e o tempo por um _Clock."""
+    """Máquina de estados + observabilidade (#36) + divisão de calls (#34).
+
+    O registro do Windows é substituído por um fake de _mic_sessions (dict de
+    subchave -> (LastUsedTimeStart, LastUsedTimeStop)) e o tempo por um _Clock.
+    """
 
     def setUp(self):
         self.clock = _Clock()
         p = mock.patch.object(detector.time, "monotonic", self.clock.monotonic)
         p.start()
         self.addCleanup(p.stop)
-        self.events: list[str] = []
-        self.mic: str | None = None  # app com o mic aberto agora, ou None
+        self.events: list[tuple] = []
+        self.sessions: dict[str, tuple[int, int]] = {}
 
     def _make(self, **over) -> Detector:
-        params = dict(grace_seconds=8.0, poll_seconds=2.0, max_call_hours=4.0)
+        params = dict(grace_seconds=8.0, poll_seconds=2.0, max_call_hours=4.0, split_gap_seconds=3.0)
         params.update(over)
         det = Detector(
             Detection(**params),
-            on_call_started=lambda: self.events.append("started"),
-            on_call_ended=lambda: self.events.append("ended"),
-            on_grace=lambda: self.events.append("grace"),
-            on_grace_cancel=lambda: self.events.append("resume"),
+            on_call_started=lambda *a, **k: self.events.append(("started", k.get("probe", True))),
+            on_call_ended=lambda: self.events.append(("ended",)),
+            on_grace=lambda: self.events.append(("grace",)),
+            on_grace_cancel=lambda: self.events.append(("resume",)),
         )
-        det._sense_call = lambda: self.mic  # controla quem está em call
+        det._mic_sessions = lambda: dict(self.sessions)  # registro controlado
         self.det = det
         return det
 
-    def _poll(self, mic: str | None, advance: float = 0.0) -> None:
+    def _poll(self, sessions: dict[str, tuple[int, int]], advance: float = 0.0) -> None:
         if advance:
             self.clock.advance(advance)
-        self.mic = mic
+        self.sessions = sessions
         self.det.poll_once()
+
+    def _starts(self) -> list[tuple]:
+        return [e for e in self.events if e[0] == "started"]
 
     # -------- transições básicas --------
 
     def test_idle_para_recording(self):
         self._make()
-        self._poll("Teams")
+        self._poll({TEAMS: (_BASE, 0)})
         self.assertIs(self.det.state, CallState.RECORDING)
-        self.assertEqual(self.events, ["started"])
+        self.assertEqual(self.events, [("started", True)])  # início normal roda a sonda
+        self.assertEqual(self.det._session_sub, TEAMS)
 
     def test_grace_e_encerramento_por_timeout(self):
         self._make()
-        self._poll("Teams")
+        self._poll({TEAMS: (_BASE, 0)})
         with self.assertLogs("scriba.detector", "INFO") as cm:
-            self._poll(None)  # mic liberado -> GRACE
+            self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)})  # mic liberado -> GRACE
         self.assertIs(self.det.state, CallState.GRACE)
         self.assertIn("mic liberado (Teams) - tolerância de 8s", "\n".join(cm.output))
         with self.assertLogs("scriba.detector", "INFO") as cm:
-            self._poll(None, advance=9.0)  # passou o grace inteiro
+            self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)}, advance=9.0)  # passou o grace
         self.assertIs(self.det.state, CallState.IDLE)
         self.assertIn("call encerrada (mic livre > 8s)", "\n".join(cm.output))
-        self.assertEqual(self.events, ["started", "grace", "ended"])
+        self.assertEqual(self.events, [("started", True), ("grace",), ("ended",)])
 
-    # -------- resume e o gap medido (#36) --------
+    # -------- resume vs. split, mesma subchave (o incidente 2026-07-02) --------
 
-    def test_resume_dentro_do_grace_loga_gap(self):
-        self._make()
-        self._poll("Teams")
-        self._poll(None)  # -> GRACE
+    def test_resume_abaixo_do_limiar_emenda(self):
+        self._make()  # split_gap_seconds=3
+        self._poll({TEAMS: (_BASE, 0)})
+        self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)})  # GRACE, guarda stop
+        new_start = _BASE + 100 * _FT + 2 * _FT  # mic reabre 2 s depois (< 3)
         with self.assertLogs("scriba.detector", "INFO") as cm:
-            self._poll("Teams", advance=4.0)  # mic volta em 4s (mesma call)
+            self._poll({TEAMS: (new_start, 0)}, advance=2.0)
         self.assertIs(self.det.state, CallState.RECORDING)
-        self.assertIn("mic voltou após 4.0s - mesma call", "\n".join(cm.output))
-        self.assertIn("resume", self.events)
+        self.assertIn("mic voltou após 2.0s - mesma call", "\n".join(cm.output))
+        self.assertEqual(len(self._starts()), 1)  # não dividiu: uma call só
 
-    def test_resume_em_app_diferente_loga_warning(self):
-        # Teams libera o mic e o Zoom pega dentro do grace: hoje emenda na mesma
-        # gravação (a fusão do incidente 2026-07-02); o log tem de deixar isso VISÍVEL.
+    def test_split_acima_do_limiar_divide(self):
+        # o incidente: Teams (call 1) libera e a MESMA subchave reabre após 5 s (call 2)
         self._make()
-        self._poll("Teams")
-        self._poll(None)  # -> GRACE
-        with self.assertLogs("scriba.detector", "WARNING") as cm:
-            self._poll("Zoom", advance=3.0)
+        self._poll({TEAMS: (_BASE, 0)})
+        self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)})  # GRACE, stop = BASE+100s
+        new_start = _BASE + 100 * _FT + 5 * _FT  # gap de 5 s (>= 3)
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll({TEAMS: (new_start, 0)}, advance=5.0)
+        out = "\n".join(cm.output)
+        self.assertIn("gap de 5.0s >= split_gap_seconds=3", out)
+        self.assertIn("dividindo a gravação", out)
+        self.assertIs(self.det.state, CallState.RECORDING)  # já gravando a call 2
+        self.assertIn(("ended",), self.events)              # parte 1 enfileirada
+        self.assertIn(("started", False), self.events)      # parte 2 sem sonda de áudio
+        self.assertEqual(self.det._session_start, new_start)
+
+    def test_split_usa_relogio_quando_filetime_desconhecido(self):
+        # LastUsedTimeStart == 0 (leitura falhou): cai no gap por relógio de parede
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})
+        self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)})  # GRACE
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll({TEAMS: (0, 0)}, advance=2.0)  # start desconhecido, 2 s de relógio
         self.assertIs(self.det.state, CallState.RECORDING)
+        self.assertIn("mic voltou após 2.0s - mesma call", "\n".join(cm.output))
+        self.assertEqual(len(self._starts()), 1)
+
+    # -------- split por troca de app monitorado --------
+
+    def test_split_troca_de_app_no_resume(self):
+        # Teams libera o mic e o Zoom o pega dentro do grace -> nova call
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})
+        self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)})  # GRACE
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll({TEAMS: (_BASE, _BASE + 100 * _FT), ZOOM: (_BASE + 102 * _FT, 0)}, advance=2.0)
+        out = "\n".join(cm.output)
+        self.assertIn("app diferente (Teams -> Zoom)", out)
+        self.assertIn("dividindo a gravação", out)
+        self.assertIs(self.det.state, CallState.RECORDING)
+        self.assertEqual(self.det._session_sub, ZOOM)
+        self.assertIn(("started", False), self.events)
+
+    def test_split_teams_para_zoom_sem_gap(self):
+        # Teams fecha e Zoom abre entre o mesmo par de polls (sem passar pelo GRACE)
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll({TEAMS: (_BASE, _BASE + 100 * _FT), ZOOM: (_BASE + 100 * _FT, 0)})
+        out = "\n".join(cm.output)
+        self.assertIn("app trocou", out)
+        self.assertIn("dividindo a gravação", out)
+        self.assertIs(self.det.state, CallState.RECORDING)
+        self.assertEqual(self.det._session_sub, ZOOM)
+
+    # -------- ciclo de sessão invisível: v1 só loga, não divide --------
+
+    def test_ciclo_invisivel_so_loga(self):
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})  # RECORDING, session_start = BASE
+        with self.assertLogs("scriba.detector", "WARNING") as cm:
+            self._poll({TEAMS: (_BASE + 50 * _FT, 0)})  # mesma subchave, start reescrito
+        self.assertIs(self.det.state, CallState.RECORDING)  # NÃO dividiu
+        self.assertIn("ciclo de sessão invisível", "\n".join(cm.output))
+        self.assertEqual(self.det._session_start, _BASE + 50 * _FT)  # rastreamento atualizado
+        self.assertEqual(len(self._starts()), 1)
+
+    # -------- split_gap_seconds = 0 desliga (comportamento antigo) --------
+
+    def test_split_desligado_emenda_mesma_sub(self):
+        self._make(split_gap_seconds=0.0)
+        self._poll({TEAMS: (_BASE, 0)})
+        self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)})  # GRACE
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll({TEAMS: (_BASE + 200 * _FT, 0)}, advance=5.0)  # gap 5 s, mas split off
+        self.assertIs(self.det.state, CallState.RECORDING)
+        self.assertIn("mesma call", "\n".join(cm.output))
+        self.assertEqual(len(self._starts()), 1)  # não dividiu
+
+    def test_split_desligado_app_diferente_emenda(self):
+        self._make(split_gap_seconds=0.0)
+        self._poll({TEAMS: (_BASE, 0)})
+        self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)})  # GRACE
+        with self.assertLogs("scriba.detector", "WARNING") as cm:
+            self._poll({TEAMS: (_BASE, _BASE + 100 * _FT), ZOOM: (_BASE + 102 * _FT, 0)}, advance=2.0)
         out = "\n".join(cm.output)
         self.assertIn("app diferente", out)
-        self.assertIn("Teams -> Zoom", out)
-
-    # -------- troca de app sem grace (Teams -> Zoom direto) --------
-
-    def test_troca_de_app_durante_recording_loga_warning(self):
-        self._make()
-        self._poll("Teams")  # RECORDING
-        self._poll("Teams")  # segue igual, sem aviso
-        with self.assertLogs("scriba.detector", "WARNING") as cm:
-            self._poll("Zoom")  # troca sem passar pelo grace
+        self.assertIn("split desligado", out)
         self.assertIs(self.det.state, CallState.RECORDING)
-        self.assertIn(
-            "troca de app monitorado durante a call: Teams -> Zoom", "\n".join(cm.output)
-        )
+        self.assertEqual(self.det._session_sub, ZOOM)  # emendou rastreando o Zoom
+        self.assertEqual(len(self._starts()), 1)
+
+    # -------- gap > grace: a call já dividia pelo timeout (preservado) --------
+
+    def test_gap_maior_que_grace_gera_duas_calls(self):
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})
+        self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)})  # GRACE
+        self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)}, advance=9.0)  # grace expira -> IDLE
+        self.assertIs(self.det.state, CallState.IDLE)
+        self._poll({TEAMS: (_BASE + 300 * _FT, 0)}, advance=1.0)  # mic reabre depois -> call nova
+        self.assertIs(self.det.state, CallState.RECORDING)
+        self.assertEqual(len(self._starts()), 2)
 
     # -------- parada de segurança por max_call_hours --------
 
     def test_max_call_hours_encerra_e_loga(self):
         self._make(max_call_hours=1.0)
-        self._poll("Teams")
+        self._poll({TEAMS: (_BASE, 0)})
         with self.assertLogs("scriba.detector", "INFO") as cm:
-            self._poll("Teams", advance=3601.0)  # > 1h com o mic ainda aberto
+            self._poll({TEAMS: (_BASE, 0)}, advance=3601.0)  # > 1h com o mic aberto
         self.assertIs(self.det.state, CallState.IDLE)
         self.assertIn("limite de segurança de 1h", "\n".join(cm.output))
-        self.assertEqual(self.events, ["started", "ended"])
+        self.assertIn(("ended",), self.events)
 
     # -------- rate-limit do log de exceções do loop --------
 
     def test_excecao_no_poll_logada_uma_vez_por_minuto(self):
         det = self._make()
-        det._sense_call = mock.Mock(side_effect=RuntimeError("registro falhou"))
+        det._mic_sessions = mock.Mock(side_effect=RuntimeError("registro falhou"))
         with self.assertLogs("scriba.detector", "ERROR") as cm:
             det.run(_StopAfter(2))  # 2 polls no MESMO instante
         falhas = [line for line in cm.output if "falha no poll" in line]
@@ -183,7 +275,7 @@ class DetectorStateMachineTests(unittest.TestCase):
 
     def test_excecao_no_poll_volta_a_logar_apos_60s(self):
         det = self._make()
-        det._sense_call = mock.Mock(side_effect=RuntimeError("registro falhou"))
+        det._mic_sessions = mock.Mock(side_effect=RuntimeError("registro falhou"))
         with self.assertLogs("scriba.detector", "ERROR") as cm:
             det.run(_StopAfter(1))
         self.assertEqual(len(cm.output), 1)


### PR DESCRIPTION
Fecha #34. **Empilhado sobre #39 (#36)** - a base é a branch de observabilidade; revisar após #39 mergear (o GitHub reaponta para main).

## O bug (incidente 2026-07-02)
Sair da daily de um cliente e entrar na call interna em segundos virou UMA gravação/nota de 66 min - misturando contexto de clientes distintos. Causa: o detector só lia `LastUsedTimeStop` do registro de mic; o `LastUsedTimeStart` reescrito (o app fecha+reabre o mic na fronteira de call) era ignorado, e o resume do GRACE emendava incondicionalmente.

## O que muda
- `_iter_mic_keys` passa a expor `(sub, start, stop)`; nova `active_sessions()`; o detector **rastreia a subchave + start (FILETIME)** que sustenta a call.
- Ao entrar no GRACE, guarda o `LastUsedTimeStop` **exato** da subchave rastreada.
- **No resume**, decide por subchave e gap:
  - outra subchave (Teams→Zoom) → **split** sempre;
  - mesma subchave, `gap >= split_gap_seconds` → **split** (é o incidente); senão emenda (troca de fone).
  - gap por **FILETIME**, com fallback no relógio de parede se a leitura falhar.
- **Em RECORDING**: Teams→Zoom sem gap (rastreada fechou + outra em uso) → split; **ciclo de sessão invisível** (start reescrito entre polls) só loga - a v1 não divide (indistinguível de troca de device; o título de #35 desempata).
- O **split** encerra a parte 1 (fila serial normal) e começa a parte 2 na **mesma iteração**, pulando a sonda de áudio (`probe=False`: os dispositivos funcionavam há < `poll_seconds`).

## Config
`[detection] split_gap_seconds = 3` (0 desliga e mantém o comportamento antigo) + `Stepper` na aba Detecção. Só age entre `~poll_seconds` e `grace_seconds`; acima disso a call já dividia pelo timeout do GRACE.

## Testes
14 casos da máquina de estados (fake de `active_sessions` + relógio controlado): resume abaixo do limiar, split acima (o incidente), fallback por relógio, troca de app no resume, Teams→Zoom sem gap, ciclo invisível só loga, `split_gap_seconds=0` desliga, gap > grace preservado, `max_call_hours`. Suíte: `test_detector` 21/21 (os 14 erros da suíte completa são `numpy`/`pystray` ausentes localmente; o CI instala via `pip install -e .`).

## Limitações v1 (issues próprias)
Gap < `poll_seconds` não divide por gap (fica p/ o título, #35). Recuperação de fusões residuais: corte retroativo `scribadev split` (#37).