### PR TITLE
feat(cli): scribadev split - corte retroativo de reuniao em duas (#37)

### DIFF
--- a/scriba/cli.py
+++ b/scriba/cli.py
@@ -98,6 +98,14 @@ def main(argv: list[str] | None = None) -> int:
     p_proc.add_argument("--speakers", type=int, default=None, metavar="N",
                         help="nº de participantes remotos: trava a diarização em N vozes (persiste no meta)")
 
+    p_split = sub.add_parser(
+        "split", help="corta uma reunião já processada em duas no offset dado (#37)"
+    )
+    p_split.add_argument("folder", type=Path)
+    p_split.add_argument(
+        "offset", help="ponto do corte relativo ao início: HH:MM:SS, MM:SS ou SS"
+    )
+
     sub.add_parser("devices", help="lista dispositivos de áudio (microfone e loopback)")
     sub.add_parser("detect", help="modo debug: imprime as transições de estado da detecção")
     sub.add_parser("wizard", help="assistente de perfil: gera o prompt.md e as hotwords")
@@ -159,6 +167,8 @@ def main(argv: list[str] | None = None) -> int:
         from .pipeline import summarize_folder
 
         return summarize_folder(args.folder)
+    if args.cmd == "split":
+        return cmd_split(args)
     if args.cmd == "process":
         from .pipeline import process_folder, process_when_ready
 
@@ -213,6 +223,24 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_update(args)
     parser.error(f"comando desconhecido: {args.cmd}")
     return 2
+
+
+def cmd_split(args) -> int:
+    """`scribadev split <pasta> <offset>`: corte retroativo de uma reunião em duas (#37)."""
+    from .split import SplitError, parse_offset, split_recording
+
+    try:
+        offset = parse_offset(args.offset)
+    except ValueError as e:
+        print(f"erro: {e}")
+        return 2
+    try:
+        folder1, folder2 = split_recording(args.folder, offset)
+    except SplitError as e:
+        print(f"erro: {e}")
+        return 1
+    print(f"dividido em duas reuniões:\n  parte 1: {folder1}\n  parte 2: {folder2}")
+    return 0
 
 
 def cmd_search(args) -> int:

--- a/scriba/split.py
+++ b/scriba/split.py
@@ -1,0 +1,293 @@
+"""Corte retroativo de uma gravação já processada em duas (#37).
+
+Quando duas calls consecutivas foram gravadas juntas (ver #34), este módulo divide
+a pasta em duas no offset dado, SEM re-transcrever nem re-diarizar: fatia o
+transcript.json por tempo, corta o áudio com ffmpeg `-c copy` e re-resume cada
+parte. A diarização já feita (que às vezes distingue vozes homônimas) é preservada
+- é a receita validada na cirurgia manual de 2026-07-02.
+
+Segurança: os áudios originais viram `*.orig` e só são apagados quando as DUAS
+partes reprocessam com sucesso; nada é destruído antes disso.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from . import util
+
+_TERMINAL_STATUSES = ("done", "failed")  # gravação parada, seguro de cortar
+_MIN_MARGIN = 5.0  # o offset tem de sobrar >= 5 s de cada lado
+
+
+class SplitError(Exception):
+    """Erro de validação/execução do corte, com mensagem pronta para o usuário."""
+
+
+# --------------------------------------------------------------- lógica pura --
+
+def parse_offset(text: str) -> float:
+    """'HH:MM:SS', 'MM:SS' ou 'SS' -> segundos (float). ValueError se inválido."""
+    parts = (text or "").strip().split(":")
+    if not 1 <= len(parts) <= 3:
+        raise ValueError(f"offset inválido: {text!r} (use HH:MM:SS, MM:SS ou SS)")
+    try:
+        nums = [float(p) for p in parts]
+    except ValueError:
+        raise ValueError(f"offset inválido: {text!r} (use HH:MM:SS, MM:SS ou SS)")
+    if any(n < 0 for n in nums):
+        raise ValueError(f"offset negativo: {text!r}")
+    secs = 0.0
+    for n in nums:  # base-60: [h,m,s] -> ((h*60)+m)*60+s
+        secs = secs * 60 + n
+    return secs
+
+
+def slice_transcript(turns: list[dict], offset: float) -> tuple[list[dict], list[dict]]:
+    """Fatia os turnos em (parte1, parte2) pelo offset.
+
+    Cada turno vai INTEIRO para a parte onde COMEÇA (não dá para partir o texto de
+    um turno sem timestamps por palavra); a parte 2 rebaseia os tempos para o zero.
+    Um turno que atravessa a fronteira fica na parte 1 - aceitável e visível.
+    """
+    part1: list[dict] = []
+    part2: list[dict] = []
+    for t in turns:
+        start = float(t.get("start", 0.0))
+        if start < offset:
+            part1.append(dict(t))
+        else:
+            t2 = dict(t)
+            t2["start"] = round(max(0.0, start - offset), 3)
+            t2["end"] = round(max(0.0, float(t.get("end", 0.0)) - offset), 3)
+            part2.append(t2)
+    return part1, part2
+
+
+def split_meta(
+    meta: dict, offset: float,
+    part1_audio: dict[str, float], part2_audio: dict[str, float],
+) -> tuple[dict, dict]:
+    """Deriva os metas das duas partes a partir do meta original.
+
+    part{1,2}_audio: {chave do stream -> audio_seconds do trecho cortado}.
+    Limpa title/client/export_path/speakers_recognized (o re-resumo regenera) e
+    zera o meeting_title da parte 2 (a janela não foi recapturada -> a IA titula).
+    """
+    started = datetime.fromisoformat(meta["started_at"])
+    cut_at = started + timedelta(seconds=offset)
+    total = float(meta.get("duration_seconds", 0.0))
+    _CLEAR = ("title", "client", "export_path", "speakers_recognized", "error")
+
+    meta1 = json.loads(json.dumps(meta))  # cópia funda
+    meta1["ended_at"] = cut_at.isoformat(timespec="seconds")
+    meta1["duration_seconds"] = round(offset, 1)
+    meta1["status"] = "transcribed"
+    for key, st in meta1.get("streams", {}).items():
+        if key in part1_audio:
+            st["audio_seconds"] = round(part1_audio[key], 1)
+    for k in _CLEAR:
+        meta1.pop(k, None)
+    # meeting_title mantido: a parte 1 é a reunião cujo título foi capturado
+
+    meta2 = json.loads(json.dumps(meta))
+    meta2["started_at"] = cut_at.isoformat(timespec="seconds")
+    # ended_at herda o original
+    meta2["duration_seconds"] = round(max(0.0, total - offset), 1)
+    meta2["status"] = "transcribed"
+    meta2["meeting_title"] = ""
+    for key, st in meta2.get("streams", {}).items():
+        if key in part2_audio:
+            st["audio_seconds"] = round(part2_audio[key], 1)
+        st["offset_seconds"] = 0.0  # o -ss do corte zera o início do stream 2
+    for k in _CLEAR:
+        meta2.pop(k, None)
+    return meta1, meta2
+
+
+# ------------------------------------------------------------- orquestração --
+
+def _run_ffmpeg(ff: list[str], args: list[str]) -> None:
+    proc = subprocess.run(ff + args, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise SplitError("ffmpeg falhou: " + (proc.stderr or "").strip()[-300:])
+
+
+def _audio_duration(path: Path) -> float | None:
+    """Duração do áudio em segundos via ffprobe, ou None se ffprobe indisponível."""
+    exe = shutil.which("ffprobe")
+    if not exe:
+        return None
+    try:
+        out = subprocess.run(
+            [exe, "-v", "error", "-show_entries", "format=duration",
+             "-of", "default=nw=1:nk=1", str(path)],
+            capture_output=True, text=True,
+        )
+        return float(out.stdout.strip()) if out.returncode == 0 and out.stdout.strip() else None
+    except (ValueError, OSError):
+        return None
+
+
+def _sibling_folder(base_dir: Path, when: datetime) -> Path:
+    """Cria a pasta da parte 2 no padrão ano/mês/dia/HH-MM (com colisão _N)."""
+    base = (base_dir / when.strftime("%Y") / when.strftime("%m")
+            / when.strftime("%d") / when.strftime("%H-%M"))
+    folder, n = base, 1
+    while folder.exists():
+        n += 1
+        folder = base.with_name(f"{base.name}_{n}")
+    folder.mkdir(parents=True)
+    return folder
+
+
+def split_recording(folder: Path, offset: float, *, reprocess: bool = True) -> tuple[Path, Path]:
+    """Divide a gravação de `folder` em duas no `offset` (segundos).
+
+    Retorna (pasta_parte1, pasta_parte2). A parte 1 REUSA a pasta original (mesmo
+    started_at -> mesma nota, que é sobrescrita); a parte 2 ganha uma pasta irmã.
+    `reprocess=False` deixa as duas prontas para `scribadev summarize` mas não
+    chama o re-resumo (usado nos testes de integração).
+    """
+    folder = Path(folder)
+    ff = util.ffmpeg_command()
+    if ff is None:
+        raise SplitError("ffmpeg não está no PATH — é pré-requisito para cortar o áudio")
+
+    meta_path = folder / "meta.json"
+    transcript_path = folder / "transcript.json"
+    if not meta_path.exists():
+        raise SplitError(f"{folder} não tem meta.json")
+    if not transcript_path.exists():
+        raise SplitError(f"{folder} não tem transcript.json — nada para fatiar")
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    if meta.get("status") not in _TERMINAL_STATUSES:
+        raise SplitError(
+            f"status '{meta.get('status')}' não é terminal — espere a reunião terminar de processar"
+        )
+    if util.is_locked(folder):
+        raise SplitError(f"{folder.name} está em processamento (.lock ativo)")
+
+    total = float(meta.get("duration_seconds", 0.0))
+    if not (_MIN_MARGIN < offset < total - _MIN_MARGIN):
+        raise SplitError(
+            f"offset {offset:.0f}s fora do intervalo válido "
+            f"({_MIN_MARGIN:.0f}s .. {total - _MIN_MARGIN:.0f}s desta gravação de {total:.0f}s)"
+        )
+
+    streams = meta.get("streams", {})
+    src = {key: folder / st["file"] for key, st in streams.items() if st.get("file")}
+    missing = [str(p) for p in src.values() if not p.exists()]
+    if missing:
+        raise SplitError("áudio ausente: " + ", ".join(missing))
+
+    # 1) fatiar o transcript (rápido e determinístico; preserva a diarização)
+    turns = json.loads(transcript_path.read_text(encoding="utf-8"))
+    part1_turns, part2_turns = slice_transcript(turns, offset)
+
+    # 2) cortar cada stream para arquivos temporários e medir a duração real.
+    # Mantém a extensão original (.opus/.flac/.wav): o ffmpeg infere o container pela
+    # extensão do arquivo de saída — um ".tmp" daria "Invalid argument". Qualquer falha
+    # aqui limpa TODOS os temporários (os originais ainda estão intactos).
+    def _tmp(path: Path, part: str) -> Path:
+        return path.parent / (path.stem + part + path.suffix)
+
+    tmp1: dict[str, Path] = {}
+    tmp2: dict[str, Path] = {}
+    part1_audio: dict[str, float] = {}
+    part2_audio: dict[str, float] = {}
+    try:
+        for key, path in src.items():
+            t1, t2 = _tmp(path, ".p1"), _tmp(path, ".p2")
+            # -c copy: corte sem recodificar (fronteira de página ~0,5 s p/ opus; ok p/
+            # playback). -t no fim (parte 1) e -ss antes do -i (parte 2, rápido).
+            _run_ffmpeg(ff, ["-y", "-i", str(path), "-t", f"{offset:.3f}", "-c", "copy", str(t1)])
+            _run_ffmpeg(ff, ["-y", "-ss", f"{offset:.3f}", "-i", str(path), "-c", "copy", str(t2)])
+            if not (t1.exists() and t2.exists() and t1.stat().st_size and t2.stat().st_size):
+                raise SplitError(f"corte de {path.name} produziu arquivo vazio")
+            tmp1[key], tmp2[key] = t1, t2
+            part1_audio[key] = _audio_duration(t1) or offset
+            part2_audio[key] = _audio_duration(t2) or max(0.0, total - offset)
+    except BaseException:
+        for path in src.values():
+            _cleanup([_tmp(path, ".p1"), _tmp(path, ".p2")])
+        raise
+
+    # 3) montar os metas e a pasta irmã da parte 2
+    meta1, meta2 = split_meta(meta, offset, part1_audio, part2_audio)
+    folder2 = _sibling_folder(_base_dir_for(folder), datetime.fromisoformat(meta2["started_at"]))
+
+    # 4) commit em 3 passadas: PRIMEIRO preserva todos os originais como *.orig
+    # (recuperável se algo falhar adiante), depois posiciona as duas partes
+    orig: list[Path] = []
+    for key, path in src.items():
+        keep = path.parent / (path.name + ".orig")
+        path.replace(keep)
+        orig.append(keep)
+    for key, path in src.items():
+        tmp1[key].replace(path)                                 # parte 1: pasta original
+    for key, path in src.items():
+        shutil.move(str(tmp2[key]), str(folder2 / path.name))   # parte 2: pasta nova
+
+    _write_json(transcript_path, part1_turns)
+    _write_json(folder2 / "transcript.json", part2_turns)
+    _write_json(meta_path, meta1)
+    _write_json(folder2 / "meta.json", meta2)
+    # voices.json (reconhecimento de voz) segue válido: copia p/ a parte 2, mantém na 1
+    voices = folder / "voices.json"
+    if voices.exists():
+        shutil.copyfile(voices, folder2 / "voices.json")
+    _cleanup([folder / "notas.md"])  # a nota da parte 1 será regravada pelo re-resumo
+
+    if not reprocess:
+        return folder, folder2
+
+    # 5) re-resume as duas (NÃO re-transcreve): a parte 1 regrava a nota antiga
+    from . import notes
+    ok1 = notes.build_notes(folder) is not None
+    ok2 = notes.build_notes(folder2) is not None
+    if ok1 and ok2:
+        _cleanup(orig)  # só descarta os originais com as duas notas prontas
+    else:
+        raise SplitError(
+            f"corte feito, mas o re-resumo falhou (originais preservados em *.orig). "
+            f"Rode: scribadev summarize \"{folder}\" e \"{folder2}\""
+        )
+
+    # 6) o índice é cache derivado das pastas: reconstrói do zero (some a fundida)
+    try:
+        from . import meetings_index
+        meetings_index.reindex()
+    except Exception:
+        pass
+    return folder, folder2
+
+
+def _base_dir_for(folder: Path) -> Path:
+    """Raiz da árvore ano/mês/dia que contém a pasta (para criar a parte 2 como irmã).
+
+    Uso normal: <gravacoes>/YYYY/MM/DD/HH-MM -> raiz = parents[3]. Pasta legada plana
+    (fora da árvore): a parte 2 vira irmã direta do mesmo diretório.
+    """
+    p = folder.resolve()
+    parents = p.parents
+    if (len(parents) >= 4 and p.parent.name.isdigit() and len(p.parent.name) == 2
+            and parents[1].name.isdigit() and parents[2].name.isdigit()):
+        return parents[3]
+    return p.parent
+
+
+def _write_json(path: Path, data) -> None:
+    util.atomic_write_text(path, json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def _cleanup(paths: list[Path]) -> None:
+    for p in paths:
+        try:
+            p.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,0 +1,127 @@
+"""Testes da lógica pura do corte retroativo (scriba.split, #37).
+
+O orquestrador split_recording (ffmpeg + arquivos + re-resumo) é validado por
+integração; aqui cobrimos as três funções puras: parse_offset, slice_transcript
+e split_meta.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scriba.split import parse_offset, slice_transcript, split_meta  # noqa: E402
+
+
+class ParseOffsetTests(unittest.TestCase):
+    def test_formatos_validos(self):
+        self.assertEqual(parse_offset("90"), 90.0)
+        self.assertEqual(parse_offset("11:20"), 680.0)
+        self.assertEqual(parse_offset("0:05"), 5.0)
+        self.assertEqual(parse_offset("1:02:03"), 3723.0)
+        self.assertEqual(parse_offset("  11:03  "), 663.0)  # aparado
+        self.assertAlmostEqual(parse_offset("2:30.5"), 150.5)
+
+    def test_invalidos(self):
+        for bad in ("abc", "1:2:3:4", "", ":", "1:xx"):
+            with self.assertRaises(ValueError):
+                parse_offset(bad)
+
+    def test_negativo(self):
+        with self.assertRaises(ValueError):
+            parse_offset("-5")
+
+
+class SliceTranscriptTests(unittest.TestCase):
+    def _turns(self):
+        return [
+            {"start": 0.0, "end": 10.0, "speaker": "Eu", "text": "a"},
+            {"start": 100.0, "end": 110.0, "speaker": "Guilherme", "text": "b"},
+            {"start": 250.0, "end": 260.0, "speaker": "Eu", "text": "c"},
+        ]
+
+    def test_divide_por_offset(self):
+        p1, p2 = slice_transcript(self._turns(), 200.0)
+        self.assertEqual([t["text"] for t in p1], ["a", "b"])
+        self.assertEqual([t["text"] for t in p2], ["c"])
+
+    def test_parte2_rebaseia_o_tempo(self):
+        _p1, p2 = slice_transcript(self._turns(), 200.0)
+        self.assertEqual(p2[0]["start"], 50.0)   # 250 - 200
+        self.assertEqual(p2[0]["end"], 60.0)     # 260 - 200
+
+    def test_turno_na_fronteira_vai_para_onde_comeca(self):
+        # um turno que atravessa o corte (start < offset <= end) fica INTEIRO na parte 1
+        turns = [{"start": 190.0, "end": 210.0, "speaker": "Eu", "text": "x"}]
+        p1, p2 = slice_transcript(turns, 200.0)
+        self.assertEqual(len(p1), 1)
+        self.assertEqual(p2, [])
+
+    def test_start_exatamente_no_offset_vai_para_parte2(self):
+        turns = [{"start": 200.0, "end": 205.0, "speaker": "Eu", "text": "x"}]
+        p1, p2 = slice_transcript(turns, 200.0)
+        self.assertEqual(p1, [])
+        self.assertEqual(p2[0]["start"], 0.0)  # rebaseado e clampado
+
+    def test_nao_perde_nem_duplica_turnos(self):
+        p1, p2 = slice_transcript(self._turns(), 105.0)
+        self.assertEqual(len(p1) + len(p2), 3)
+
+    def test_nao_muta_a_entrada(self):
+        turns = self._turns()
+        slice_transcript(turns, 200.0)
+        self.assertEqual(turns[2]["start"], 250.0)  # original intacto
+
+
+class SplitMetaTests(unittest.TestCase):
+    def _meta(self):
+        return {
+            "started_at": "2026-07-02T09:30:19",
+            "ended_at": "2026-07-02T09:41:22",
+            "duration_seconds": 663.0,
+            "status": "done",
+            "streams": {
+                "mic": {"file": "mic.opus", "offset_seconds": 0.0, "audio_seconds": 663.0},
+                "loopback": {"file": "loopback.opus", "offset_seconds": 0.0, "audio_seconds": 663.0},
+            },
+            "meeting_title": "Daily reforma tributária Coruripe",
+            "title": "Daily reforma tributária Coruripe",
+            "client": "Coruripe",
+            "export_path": "C:\\x\\2026-07-02_09-30_reuniao.md",
+            "speakers_recognized": ["Guilherme Lima"],
+        }
+
+    def test_parte1(self):
+        m1, _m2 = split_meta(self._meta(), 300.0, {"mic": 300.0, "loopback": 300.0}, {"mic": 363.0, "loopback": 363.0})
+        self.assertEqual(m1["started_at"], "2026-07-02T09:30:19")  # início preservado
+        self.assertEqual(m1["ended_at"], "2026-07-02T09:35:19")    # início + 300 s
+        self.assertEqual(m1["duration_seconds"], 300.0)
+        self.assertEqual(m1["status"], "transcribed")
+        self.assertEqual(m1["streams"]["mic"]["audio_seconds"], 300.0)
+        self.assertEqual(m1["meeting_title"], "Daily reforma tributária Coruripe")  # mantido
+        for k in ("title", "client", "export_path", "speakers_recognized"):
+            self.assertNotIn(k, m1)  # limpos p/ o re-resumo regenerar
+
+    def test_parte2(self):
+        _m1, m2 = split_meta(self._meta(), 300.0, {"mic": 300.0, "loopback": 300.0}, {"mic": 363.0, "loopback": 363.0})
+        self.assertEqual(m2["started_at"], "2026-07-02T09:35:19")  # início + 300 s
+        self.assertEqual(m2["ended_at"], "2026-07-02T09:41:22")    # fim original preservado
+        self.assertEqual(m2["duration_seconds"], 363.0)            # 663 - 300
+        self.assertEqual(m2["status"], "transcribed")
+        self.assertEqual(m2["meeting_title"], "")                  # zerado -> IA titula
+        self.assertEqual(m2["streams"]["mic"]["audio_seconds"], 363.0)
+        self.assertEqual(m2["streams"]["mic"]["offset_seconds"], 0.0)
+        for k in ("title", "client", "export_path", "speakers_recognized"):
+            self.assertNotIn(k, m2)
+
+    def test_nao_muta_o_meta_original(self):
+        meta = self._meta()
+        split_meta(meta, 300.0, {"mic": 300.0}, {"mic": 363.0})
+        self.assertEqual(meta["status"], "done")           # original intacto
+        self.assertEqual(meta["duration_seconds"], 663.0)
+        self.assertIn("title", meta)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fecha #37. **Independe do #34/#36** (base `main`) - é a ferramenta de recuperação para fusões residuais.

## O que faz
`scribadev split <pasta> <offset>` divide uma gravação já processada em duas no ponto dado (offset `HH:MM:SS`, `MM:SS` ou `SS`), **sem re-transcrever nem re-diarizar**.

## Abordagem (receita validada na cirurgia manual de 2026-07-02)
A spec original da issue falava em reprocessar do zero; a cirurgia manual do incidente validou uma abordagem melhor, que este PR segue:
- **fatia o `transcript.json`** por tempo (a parte 2 rebaseia os timestamps para zero);
- **corta o áudio** com `ffmpeg -c copy` (lossless, rápido);
- **re-resume** cada parte (`build_notes`).

Preserva a diarização já feita - que às vezes distingue vozes homônimas (no incidente, separou "Guilherme Lima" o GP de "Guilherme" o dev). É rápido e determinístico.

## Fluxo
- Validações antes de tocar em arquivo: `meta`+`transcript`+áudio presentes, status terminal (`done`/`failed`), sem `.lock` ativo, offset entre 5s e duração-5s, ffmpeg no PATH.
- A **parte 1 reusa a pasta original** (mesmo `started_at` → `_export_stem` gera o mesmo nome de nota, que é sobrescrita); a **parte 2** ganha pasta irmã na árvore ano/mês/dia (colisão `_N`), derivada da posição da pasta original (funciona fora do `recordings_dir` também).
- **Segurança:** os áudios originais viram `*.orig` e só são apagados quando as **duas** partes reprocessam com sucesso. Qualquer falha nos cortes limpa os temporários **sem tocar os originais**.
- Reindexa ao final (o índice é cache derivado das pastas).

## Divergência consciente da spec
Sem `--speakers1/2` nem re-diarização: a receita validada preserva o `transcript.json` existente, então não há o que re-diarizar.

## Testes
- **12 casos da lógica pura**: `parse_offset` (formatos válidos/inválidos/negativo), `slice_transcript` (divisão, rebaseamento, turno na fronteira, não-mutação), `split_meta` (metas das 2 partes, campos limpos, não-mutação).
- **Orquestrador validado por integração**: corte real de uma cópia da gravação de 2026-07-02 (300s) → parte 1 de 300s + parte 2 de 363s, timestamps rebaseados, `.orig` preservados, zero temporários órfãos.
- Suíte completa sem regressão (os 14 erros são `numpy`/`pystray` ausentes localmente; o CI instala via `pip install -e .`).