### PR TITLE
feat(detector): titulo da janela como 2o sinal do split (#35)

### DIFF
--- a/scriba/detector.py
+++ b/scriba/detector.py
@@ -27,6 +27,10 @@ _BASE = r"Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\Cons
 
 log = logging.getLogger("scriba.detector")
 
+# a cada quantos polls reamostrar o título da janela durante a gravação (#35).
+# 5 polls x poll_seconds(2s) ~= 10 s; EnumWindows é barato (a camada web já paga).
+_TITLE_SAMPLE_EVERY = 5
+
 
 class CallState(Enum):
     IDLE = "idle"
@@ -284,6 +288,7 @@ class Detector:
         on_call_ended: Callable[[], None],
         on_grace: Callable[[], None] | None = None,
         on_grace_cancel: Callable[[], None] | None = None,
+        on_title: Callable[[str], None] | None = None,
     ):
         self.cfg = cfg
         self.patterns = patterns_from(cfg)
@@ -297,6 +302,7 @@ class Detector:
         self.on_call_ended = on_call_ended
         self.on_grace = on_grace  # mic liberado: esperando a tolerância
         self.on_grace_cancel = on_grace_cancel  # mic voltou: era troca de device
+        self.on_title = on_title  # título estável capturado (bônus #35: meta tardio)
         self.state = CallState.IDLE
         self._grace_deadline = 0.0
         self._grace_since = 0.0  # entrada no GRACE (para medir o gap do resume)
@@ -306,6 +312,11 @@ class Detector:
         self._session_sub: str | None = None   # subchave do registro
         self._session_start = 0                 # LastUsedTimeStart (FILETIME) no início
         self._session_stop = 0                  # LastUsedTimeStop guardado ao entrar no GRACE
+        # sinal de título da reunião (#35): desempata splits ambíguos do #34
+        self._title_last = ""        # última amostra de título
+        self._title_stable = ""      # título estável (2 amostras iguais e não-vazias)
+        self._title_at_grace = ""    # título estável guardado ao entrar no GRACE (Uso A)
+        self._polls_since_title = 0  # contador para reamostrar a cada _TITLE_SAMPLE_EVERY
 
     def _mic_sessions(self) -> dict[str, tuple[int, int]]:
         """{subchave: (start, stop)} das sessões de mic de apps e navegadores
@@ -349,6 +360,23 @@ class Detector:
                 return None  # mic no navegador, mas nenhum título de reunião ainda
         return None
 
+    def _sample_title(self) -> None:
+        """Reamostra o título da janela a cada _TITLE_SAMPLE_EVERY polls e mantém o
+        'título estável' (2 amostras iguais e não-vazias). Uso C (#35): se o estável
+        muda sem nenhum evento de sessão de mic, só alerta - a v1 não divide por isso."""
+        self._polls_since_title += 1
+        if self._polls_since_title < _TITLE_SAMPLE_EVERY:
+            return
+        self._polls_since_title = 0
+        t = capture_meeting_title(self.cfg)
+        if t and t == self._title_last and t != self._title_stable:  # 2 amostras iguais
+            if self._title_stable:  # Uso C: estável mudou sem ciclo/gap de mic
+                log.warning("possível nova call sem ciclo de mic: %s -> %s", self._title_stable, t)
+            self._title_stable = t
+            if self.on_title:  # bônus: preenche o meeting_title tardio no meta
+                self.on_title(t)
+        self._title_last = t
+
     def poll_once(self) -> None:
         now = time.monotonic()
         sessions = self._mic_sessions()
@@ -363,6 +391,7 @@ class Detector:
                 self._begin(now, sense)
 
         elif self.state is CallState.RECORDING:
+            self._sample_title()  # #35: reamostra o título da janela ~a cada 10 s
             if not in_use:
                 # mic liberado -> GRACE. Guarda o LastUsedTimeStop EXATO da subchave
                 # rastreada: o instante em que o app fechou o mic, sem depender do poll.
@@ -370,6 +399,7 @@ class Detector:
                 self._grace_since = now
                 self._grace_deadline = now + self.cfg.grace_seconds
                 self._session_stop = sessions.get(self._session_sub or "", (0, 0))[1]
+                self._title_at_grace = self._title_stable  # título de antes do gap (Uso A)
                 log.info(
                     "mic liberado (%s) - tolerância de %.0fs",
                     self.current_app, self.cfg.grace_seconds,
@@ -407,9 +437,18 @@ class Detector:
             log.warning("troca de app monitorado durante a call: %s -> %s", prev_app, sense[0])
             self._session_sub, self._session_start = sub, start
         elif tracked is not None and tracked[1] == 0 and start != self._session_start:
-            # MESMA subchave, mas o start foi reescrito: o mic reabriu entre dois
-            # polls (gap < poll). Indistinguível de troca de device -> v1 NÃO divide;
-            # o sinal de título (#35) desempata. Loga e atualiza o rastreamento.
+            # MESMA subchave, mas o start foi reescrito: o mic reabriu entre dois polls
+            # (gap < poll). O registro não distingue de uma troca de device — #35 usa
+            # o título de desempate: mudou => call nova; igual/vazio => não divide.
+            now_title = capture_meeting_title(self.cfg)
+            if (self.cfg.split_gap_seconds > 0 and self._title_stable and now_title
+                    and now_title != self._title_stable):
+                log.info(
+                    "ciclo invisível + título mudou (%s -> %s) - dividindo a gravação",
+                    self._title_stable, now_title,
+                )
+                self._split(now, sessions)
+                return
             log.warning(
                 "ciclo de sessão invisível em %s (start mudou) - nao divido na v1",
                 self.current_app,
@@ -444,13 +483,23 @@ class Detector:
             gap = self._filetime_gap(start, self._session_stop)
             gap = gap_wall if gap is None else gap
             if split_on and gap >= self.cfg.split_gap_seconds:
-                log.info(
-                    "gap de %.1fs >= split_gap_seconds=%g - dividindo a gravação",
-                    gap, self.cfg.split_gap_seconds,
-                )
-                self._split(now, sessions)
-                return
-            log.info("mic voltou após %.1fs - mesma call", gap)
+                # #35: título igual ao de antes do gap => mesma reunião (troca de fone
+                # lenta) => suprime o split. Em dúvida NÃO divide (fusão é recuperável).
+                now_title = capture_meeting_title(self.cfg)
+                if self._title_at_grace and now_title and now_title == self._title_at_grace:
+                    log.info(
+                        "gap de %.1fs, mas título inalterado (%s) - NÃO divido (mesma reunião)",
+                        gap, now_title,
+                    )
+                else:
+                    log.info(
+                        "gap de %.1fs >= split_gap_seconds=%g - dividindo a gravação",
+                        gap, self.cfg.split_gap_seconds,
+                    )
+                    self._split(now, sessions)
+                    return
+            else:
+                log.info("mic voltou após %.1fs - mesma call", gap)
 
         # emenda (resume): atualiza o rastreamento e volta a RECORDING
         self.state = CallState.RECORDING
@@ -465,6 +514,9 @@ class Detector:
         self.state = CallState.RECORDING
         self._recording_since = now
         self._session_sub, self._session_start = sub, start
+        # nova call: zera o rastreamento de título (#35)
+        self._title_last = self._title_stable = self._title_at_grace = ""
+        self._polls_since_title = 0
         self.on_call_started(probe=probe)
 
     def _end_call(self) -> None:

--- a/scriba/main.py
+++ b/scriba/main.py
@@ -332,6 +332,27 @@ class ScribaApp:
         except Exception:
             log.exception("não consegui gravar num_speakers no meta de %s", getattr(folder, "name", folder))
 
+    def _on_title(self, title: str) -> None:
+        """Título estável capturado durante a gravação (#35): preenche meeting_title
+        no meta da gravação ATIVA se ele estava vazio — melhora a nota e o índice de
+        busca para calls que demoram a expor o título. Roda na thread do detector."""
+        import json
+
+        with self.rec_lock:
+            rec = self.rec
+        if rec is None:
+            return
+        meta_path = rec.folder / "meta.json"
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            if meta.get("meeting_title"):
+                return  # já tem título de janela: não sobrescreve
+            meta["meeting_title"] = title
+            util.atomic_write_text(meta_path, json.dumps(meta, ensure_ascii=False, indent=2))
+            log.info("meeting_title capturado tardiamente: %s (%s)", title, rec.folder.name)
+        except Exception:
+            log.exception("não consegui gravar meeting_title tardio em %s", rec.folder.name)
+
     def _set_speakers_live(self, n: int) -> None:
         """Pílula definiu o nº de participantes durante a call (#13): grava no meta da
         gravação ATIVA. O fim da call lê isso e dispensa a janela de perguntar."""
@@ -891,6 +912,7 @@ class ScribaApp:
             # feedback imediato ao desligar a call: a pílula avisa que está na tolerância
             on_grace=lambda: self.ui(self._pill_finishing),
             on_grace_cancel=lambda: self.ui(self._pill_resume),
+            on_title=self._on_title,  # #35: preenche meeting_title tardio no meta
         )
         threading.Thread(target=self.detector.run, args=(self.stop_event,), daemon=True, name="detector").start()
         threading.Thread(target=self._worker, daemon=True, name="worker").start()

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -9,7 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scriba import detector  # noqa: E402
 from scriba.config import Detection  # noqa: E402
-from scriba.detector import CallState, Detector, _clean_meeting_title  # noqa: E402
+from scriba.detector import CallState, Detector, _TITLE_SAMPLE_EVERY, _clean_meeting_title  # noqa: E402
 
 # FILETIME é contado em intervalos de 100 ns desde 1601.
 _FT = 10_000_000                     # 1 segundo
@@ -87,6 +87,11 @@ class DetectorStateMachineTests(unittest.TestCase):
         p = mock.patch.object(detector.time, "monotonic", self.clock.monotonic)
         p.start()
         self.addCleanup(p.stop)
+        # capture_meeting_title fake (#35): sem isto os testes leriam janelas reais
+        self.title = ""
+        pt = mock.patch.object(detector, "capture_meeting_title", lambda cfg: self.title)
+        pt.start()
+        self.addCleanup(pt.stop)
         self.events: list[tuple] = []
         self.sessions: dict[str, tuple[int, int]] = {}
 
@@ -99,6 +104,7 @@ class DetectorStateMachineTests(unittest.TestCase):
             on_call_ended=lambda: self.events.append(("ended",)),
             on_grace=lambda: self.events.append(("grace",)),
             on_grace_cancel=lambda: self.events.append(("resume",)),
+            on_title=lambda t: self.events.append(("title", t)),
         )
         det._mic_sessions = lambda: dict(self.sessions)  # registro controlado
         self.det = det
@@ -283,6 +289,81 @@ class DetectorStateMachineTests(unittest.TestCase):
         with self.assertLogs("scriba.detector", "ERROR") as cm:
             det.run(_StopAfter(1))  # já passou 1 min -> loga de novo
         self.assertEqual(len(cm.output), 1)
+
+    # -------- título como 2º sinal do split (#35) --------
+
+    def test_amostragem_estabiliza_titulo(self):
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})  # RECORDING
+        self.title = "Daily Coruripe"
+        for _ in range(2 * _TITLE_SAMPLE_EVERY + 1):  # 2 amostragens iguais
+            self._poll({TEAMS: (_BASE, 0)})
+        self.assertEqual(self.det._title_stable, "Daily Coruripe")
+        self.assertIn(("title", "Daily Coruripe"), self.events)  # bônus: on_title disparado
+
+    def test_uso_a_titulo_igual_suprime_split_por_gap(self):
+        # gap >= limiar, mas a reunião é a mesma (título inalterado) -> NÃO divide
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})
+        self.det._title_stable = "Daily Coruripe"       # título já estabilizado
+        self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)})  # GRACE -> guarda o título
+        self.title = "Daily Coruripe"                    # no resume, título igual
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll({TEAMS: (_BASE + 105 * _FT, 0)}, advance=5.0)  # gap de 5 s (>= 3)
+        self.assertIs(self.det.state, CallState.RECORDING)
+        self.assertIn("título inalterado", "\n".join(cm.output))
+        self.assertEqual(len(self._starts()), 1)          # emendou: uma call só
+
+    def test_uso_a_titulo_diferente_permite_split_por_gap(self):
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})
+        self.det._title_stable = "Daily Coruripe"
+        self._poll({TEAMS: (_BASE, _BASE + 100 * _FT)})  # GRACE
+        self.title = "Alinhamento interno"               # título mudou -> call nova
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll({TEAMS: (_BASE + 105 * _FT, 0)}, advance=5.0)
+        self.assertIn("dividindo a gravação", "\n".join(cm.output))
+        self.assertIn(("started", False), self.events)
+
+    def test_uso_b_ciclo_invisivel_titulo_mudou_divide(self):
+        # o caso do incidente se o Teams reabriu o mic em < poll: sem gap medível,
+        # o título muda -> divide
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})                  # RECORDING, session_start = BASE
+        self.det._title_stable = "Daily Coruripe"
+        self.title = "Alinhamento interno"               # título novo
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll({TEAMS: (_BASE + 50 * _FT, 0)})   # ciclo invisível (start mudou)
+        out = "\n".join(cm.output)
+        self.assertIn("ciclo invisível + título mudou", out)
+        self.assertIn("dividindo a gravação", out)
+        self.assertIn(("started", False), self.events)
+
+    def test_uso_b_ciclo_invisivel_titulo_igual_nao_divide(self):
+        # troca de device (mesma reunião, mesmo título) -> só WARN, não divide
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})
+        self.det._title_stable = "Daily Coruripe"
+        self.title = "Daily Coruripe"
+        with self.assertLogs("scriba.detector", "WARNING") as cm:
+            self._poll({TEAMS: (_BASE + 50 * _FT, 0)})
+        self.assertIs(self.det.state, CallState.RECORDING)
+        self.assertIn("ciclo de sessão invisível", "\n".join(cm.output))
+        self.assertEqual(len(self._starts()), 1)
+
+    def test_uso_c_titulo_muda_sem_ciclo_so_avisa(self):
+        # título estável muda sem NENHUM evento de sessão de mic -> v1 só alerta
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})
+        self.det._title_stable = "Daily Coruripe"
+        self.title = "Alinhamento interno"
+        self.det._title_last = "Alinhamento interno"       # 1ª amostra já feita
+        self.det._polls_since_title = _TITLE_SAMPLE_EVERY - 1  # força amostrar agora
+        with self.assertLogs("scriba.detector", "WARNING") as cm:
+            self._poll({TEAMS: (_BASE, 0)})                # mesma sessão, sem ciclo
+        self.assertIs(self.det.state, CallState.RECORDING)  # não divide
+        self.assertIn("possível nova call sem ciclo", "\n".join(cm.output))
+        self.assertEqual(len(self._starts()), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fecha #35. Base `main` (o #34 já está mergeado). Complementa a divisão automática do #34 usando o **título da janela** como sinal de desempate.

## Contexto
A divisão por gap do registro (#34) não cobre dois casos: (1) **ciclo invisível** - o mic fecha+reabre em < `poll_seconds`, sem gap medível; (2) **falso positivo** - uma troca de fone lenta (gap >= limiar) na mesma reunião. O título da reunião resolve os dois.

## O que muda
O detector reamostra `capture_meeting_title` a cada ~10s durante a gravação e mantém o **título estável** (2 amostras consecutivas iguais e não-vazias).

- **Uso A (suprime falso split):** no split por gap, se o título de antes do gap == título no resume (ambos não-vazios) → **não divide** (mesma reunião). Em dúvida não divide - fusão é recuperável via #37.
- **Uso B (divide sem gap medível):** no ciclo de sessão invisível, se o título **mudou** → **divide**. É o incidente de 02/07 caso o Teams tenha reaberto o mic em < 2s.
- **Uso C (mic contínuo):** título estável muda sem nenhum evento de sessão → só **WARN** na v1 (split automático fica para uma flag futura `split_on_title_change`, após observar logs reais).
- **Bônus:** callback `on_title` preenche o `meeting_title` tardio no `meta.json` da gravação ativa se estava vazio - melhora a nota e o índice de busca para calls que demoram a expor o título.

## Riscos mitigados
`capture_meeting_title` pode pegar uma janela de chat do Teams - por isso exijo **estabilidade** (2+ amostras) e só ajo quando **ambos** os lados da comparação são não-vazios. Em dúvida, não divide.

## Testes
6 casos novos com `capture_meeting_title` injetado (amostragem/estabilização, A suprime, A divide, B divide, B não-divide, C avisa) + fake global no setUp para os testes de #34 não lerem janelas reais. `test_detector` 27/27. Suíte sem regressão (14 erros = numpy/pystray locais; CI instala).