### PR TITLE
feat(ui): corte manual 'nova call' na pilula + hotkey/bandeja + rearme (#38)

### DIFF
--- a/scriba/config.py
+++ b/scriba/config.py
@@ -108,6 +108,7 @@ timeout_seconds = 600
 [ui]
 overlay = true           # pílula flutuante durante a gravação
 hotkey = ""              # atalho global gravar/parar (ex.: "ctrl+alt+r"); vazio desativa
+hotkey_split = ""        # atalho global "nova call" (divide a gravação, #38); vazio desativa
 
 [output]
 # Pasta para onde o notas.md final é copiado. Vazio = Documentos\\ScribaDev
@@ -207,6 +208,7 @@ class Summary:
 class Ui:
     overlay: bool = True
     hotkey: str = ""
+    hotkey_split: str = ""  # atalho global "nova call" / dividir a gravação (#38)
 
 
 @dataclass(frozen=True)
@@ -364,6 +366,7 @@ timeout_seconds = {_n(s.timeout_seconds)}
 [ui]
 overlay = {_b(u.overlay)}           # pílula flutuante durante a gravação
 hotkey = {_s(u.hotkey)}              # atalho global gravar/parar (ex.: "ctrl+alt+r"); vazio desativa
+hotkey_split = {_s(u.hotkey_split)}        # atalho global "nova call" (divide a gravação, #38); vazio desativa
 
 [output]
 # Pasta para onde o notas.md final é copiado. Vazio = Documentos\\ScribaDev

--- a/scriba/detector.py
+++ b/scriba/detector.py
@@ -289,6 +289,7 @@ class Detector:
         on_grace: Callable[[], None] | None = None,
         on_grace_cancel: Callable[[], None] | None = None,
         on_title: Callable[[str], None] | None = None,
+        is_recording: Callable[[], bool] | None = None,
     ):
         self.cfg = cfg
         self.patterns = patterns_from(cfg)
@@ -303,6 +304,7 @@ class Detector:
         self.on_grace = on_grace  # mic liberado: esperando a tolerância
         self.on_grace_cancel = on_grace_cancel  # mic voltou: era troca de device
         self.on_title = on_title  # título estável capturado (bônus #35: meta tardio)
+        self.is_recording = is_recording  # #38: p/ rearmar o auto-record após ■
         self.state = CallState.IDLE
         self._grace_deadline = 0.0
         self._grace_since = 0.0  # entrada no GRACE (para medir o gap do resume)
@@ -434,6 +436,8 @@ class Detector:
                 )
                 self._split(now, sessions)
                 return
+            if self._rearm_if_stopped(sense):  # ■ dado: a call nova grava sozinha
+                return
             log.warning("troca de app monitorado durante a call: %s -> %s", prev_app, sense[0])
             self._session_sub, self._session_start = sub, start
         elif tracked is not None and tracked[1] == 0 and start != self._session_start:
@@ -448,6 +452,8 @@ class Detector:
                     self._title_stable, now_title,
                 )
                 self._split(now, sessions)
+                return
+            if self._rearm_if_stopped(sense):  # ■ dado: a call nova grava sozinha
                 return
             log.warning(
                 "ciclo de sessão invisível em %s (start mudou) - nao divido na v1",
@@ -518,6 +524,18 @@ class Detector:
         self._title_last = self._title_stable = self._title_at_grace = ""
         self._polls_since_title = 0
         self.on_call_started(probe=probe)
+
+    def _rearm_if_stopped(self, sense: tuple[str, str, int]) -> bool:
+        """Rearma o auto-record quando um NOVO ciclo de sessão de mic começa mas não
+        há gravação em andamento — o usuário deu ■ com a call ainda ativa (#38). Fecha
+        a armadilha do "■ e esqueci o ⏺": a call seguinte passa a gravar sozinha."""
+        if not (self.cfg.auto_record and self.is_recording and not self.is_recording()):
+            return False
+        name, sub, start = sense
+        log.info("auto-record re-armado: novo ciclo de mic sem gravação em andamento (%s)", name)
+        self._session_sub, self._session_start = sub, start
+        self.on_call_started(probe=False)
+        return True
 
     def _end_call(self) -> None:
         """Encerra a call e volta a IDLE (timeout do GRACE ou parada de segurança)."""

--- a/scriba/main.py
+++ b/scriba/main.py
@@ -98,6 +98,7 @@ class ScribaApp:
         self.main_win = None
         self.update_news = None  # versão nova detectada (#19); a capa exibe o aviso
         self.hotkey = None
+        self.hotkey_split = None  # #38: atalho "nova call" (dividir a gravação)
         self.detector: Detector | None = None
         self.call_started_at: float | None = None
         try:
@@ -557,17 +558,24 @@ class ScribaApp:
     # -------------------------------------------------------------- hotkey --
 
     def _setup_hotkey(self) -> None:
+        # (re)registra os atalhos globais: gravar/parar e "nova call" (#38)
+        for attr in ("hotkey", "hotkey_split"):
+            hk = getattr(self, attr)
+            if hk is not None:
+                hk.stop()
+                setattr(self, attr, None)
+        self._register_hotkey("hotkey", self.cfg.ui.hotkey, self._hotkey_toggle)
+        self._register_hotkey("hotkey_split", getattr(self.cfg.ui, "hotkey_split", ""), self._split_now)
+
+    def _register_hotkey(self, attr: str, spec: str, handler) -> None:
         from .hotkey import GlobalHotkey
 
-        if self.hotkey is not None:
-            self.hotkey.stop()
-            self.hotkey = None
-        spec = (self.cfg.ui.hotkey or "").strip()
+        spec = (spec or "").strip()
         if not spec:
             return
-        hk = GlobalHotkey(spec, self._hotkey_toggle)
+        hk = GlobalHotkey(spec, handler)
         if hk.start():
-            self.hotkey = hk
+            setattr(self, attr, hk)
         else:
             log.warning("hotkey '%s' não pôde ser registrada", spec)
             self._toast("Atalho indisponível", f"Não consegui registrar '{spec}' (em uso por outro app?)")
@@ -577,6 +585,17 @@ class ScribaApp:
             self.stop_recording(keep=True)  # intenção explícita: guarda mesmo curta
         else:
             self.start_recording("manual")
+
+    def _split_now(self) -> None:
+        """✂ nova call (#38): encerra a gravação atual (guardando) e começa outra na
+        hora, num clique. Fecha a fronteira de call que o usuário SABE onde é. Pula a
+        sonda de áudio (probe=False): os dispositivos estão funcionando agora."""
+        if not self.is_recording():
+            self.start_recording("manual")  # nada gravando ainda: só começa
+            return
+        self.stop_recording(keep=True)                # parte 1 -> fila (intenção explícita)
+        self.start_recording("manual", probe=False)   # parte 2 já em andamento
+        self._toast("Gravação dividida", "Nova gravação em andamento.")
 
     # ---------------------------------------------------------------- pill --
 
@@ -597,6 +616,9 @@ class ScribaApp:
                     target=self.start_recording, args=("manual",), daemon=True
                 ).start(),
                 on_speakers=self._set_speakers_live,  # #13: nº de participantes ao vivo
+                on_split=lambda: threading.Thread(  # #38: ✂ fecha esta call e começa outra
+                    target=self._split_now, daemon=True
+                ).start(),
             )
         return self.pill
 
@@ -913,6 +935,7 @@ class ScribaApp:
             on_grace=lambda: self.ui(self._pill_finishing),
             on_grace_cancel=lambda: self.ui(self._pill_resume),
             on_title=self._on_title,  # #35: preenche meeting_title tardio no meta
+            is_recording=self.is_recording,  # #38: rearma o auto-record após ■
         )
         threading.Thread(target=self.detector.run, args=(self.stop_event,), daemon=True, name="detector").start()
         threading.Thread(target=self._worker, daemon=True, name="worker").start()

--- a/scriba/overlay.py
+++ b/scriba/overlay.py
@@ -15,7 +15,7 @@ _MUTED = "#9a9aa8"
 _RED = "#e54545"
 _RED_DIM = "#7a2626"
 _KEY = "#000001"  # cor-chave que vira transparente (cantos arredondados)
-_W, _H, _R = 264, 44, 21  # largura abriga o stepper de nº de participantes (#13)
+_W, _H, _R = 304, 44, 21  # largura abriga o stepper de participantes (#13) e o ✂ (#38)
 
 
 def _load_pos() -> list[int] | None:
@@ -109,11 +109,13 @@ class RecordingPill:
         on_discard: Callable[[], None],
         on_record: Callable[[], None] | None = None,
         on_speakers: Callable[[int], None] | None = None,
+        on_split: Callable[[], None] | None = None,
     ):
         self.on_stop = on_stop
         self.on_discard = on_discard
         self.on_record = on_record
         self.on_speakers = on_speakers
+        self.on_split = on_split  # ✂ nova call (#38): fecha esta e começa outra
         self.mode = "recording"
         self._destroyed = False
         self._pulse_on = True
@@ -156,6 +158,15 @@ class RecordingPill:
         c.tag_lower(self.stop_hit, self.stop_btn)
         c.tag_lower(self.discard_hit, self.discard_btn)
 
+        # ✂ nova call (#38): à esquerda do ■, mesmo padrão (glifo + hitbox maior).
+        # Encerra a gravação atual (guardando) e começa outra num clique.
+        self.split_btn = c.create_text(
+            _W - 96, _H // 2, text="✂", fill=_MUTED, font=("Segoe UI", 12), tags=("btn", "split")
+        )
+        self.split_hit = c.create_rectangle(_W - 108, _H // 2 - 11, _W - 84, _H // 2 + 11,
+                                            fill=_BG, outline="", tags=("btn", "split"))
+        c.tag_lower(self.split_hit, self.split_btn)
+
         # nº de participantes (#13): stepper "− N +" (modo gravação). Define o
         # num_speakers ao vivo; ao encerrar, se confirmado, dispensa a janela do fim.
         _cy = _H // 2
@@ -178,9 +189,12 @@ class RecordingPill:
         c.tag_bind("stop", "<Button-1>", lambda e: self._click(self.on_stop))
         c.tag_bind("discard", "<Button-1>", lambda e: self._click(self.on_discard))
         c.tag_bind("rec", "<Button-1>", lambda e: self._click(self._record))
+        c.tag_bind("split", "<Button-1>", lambda e: self._click(self._split))
         for tag, item in (("stop", self.stop_btn), ("discard", self.discard_btn)):
             c.tag_bind(tag, "<Enter>", lambda e, i=item: c.itemconfigure(i, fill=_RED))
             c.tag_bind(tag, "<Leave>", lambda e, i=item, f=(_FG if tag == "stop" else _MUTED): c.itemconfigure(i, fill=f))
+        c.tag_bind("split", "<Enter>", lambda e: c.itemconfigure(self.split_btn, fill=_FG))
+        c.tag_bind("split", "<Leave>", lambda e: c.itemconfigure(self.split_btn, fill=_MUTED))
         c.tag_bind("rec", "<Enter>", lambda e: c.itemconfigure(self.idle_label, fill=_RED))
         c.tag_bind("rec", "<Leave>", lambda e: c.itemconfigure(self.idle_label, fill=_FG))
         c.tag_bind("spk_dec", "<Button-1>", lambda e: self._spk_adjust(-1))
@@ -219,6 +233,10 @@ class RecordingPill:
     def _record(self) -> None:
         if self.on_record is not None:
             self.on_record()
+
+    def _split(self) -> None:
+        if self.on_split is not None:
+            self.on_split()
 
     def _on_button(self) -> bool:
         return any("btn" in self.canvas.gettags(i) for i in self.canvas.find_withtag("current"))
@@ -326,6 +344,7 @@ class RecordingPill:
         self.mode = mode
         self._status_mode = False
         rec_items = (self.dot, self.time_text, self.stop_btn, self.discard_btn,
+                     self.split_btn, self.split_hit, self.stop_hit, self.discard_hit,
                      self.spk_minus, self.spk_count, self.spk_plus)
         idle_items = (self.idle_ring, self.idle_dot, self.idle_label)
         show, hide = (rec_items, idle_items) if mode == "recording" else (idle_items, rec_items)

--- a/scriba/settings_ui.py
+++ b/scriba/settings_ui.py
@@ -444,18 +444,13 @@ class SettingsWindow:
         self.autostart_var = tk.BooleanVar()
         self._toggle_row(auto, "Iniciar com o Windows", self.autostart_var)
 
-        hk_row = tk.Frame(auto, bg=_BG)
-        hk_row.pack(fill="x", pady=6)
-        tk.Label(hk_row, text="Atalho global gravar/parar", bg=_BG, fg=PALETTE["text"], font=FONT).pack(side="left")
         self.hotkey_var = tk.StringVar(value="")
-        LinkLabel(hk_row, "limpar", lambda: self.hotkey_var.set("")).pack(side="right", padx=(8, 0))
-        ModernButton(hk_row, "Gravar atalho", self._capture_hotkey).pack(side="right", padx=(8, 0))
         self.hotkey_label_var = tk.StringVar(value="desativado")
-        tk.Label(hk_row, textvariable=self.hotkey_label_var, bg=PALETTE["field"], fg=PALETTE["text"],
-                 font=("Consolas", 9), padx=10, pady=4).pack(side="right")
-        self.hotkey_var.trace_add(
-            "write", lambda *a: self.hotkey_label_var.set(self.hotkey_var.get() or "desativado")
-        )
+        self._hotkey_row(auto, "Atalho global gravar/parar", self.hotkey_var, self.hotkey_label_var)
+        self.hotkey_split_var = tk.StringVar(value="")
+        self.hotkey_split_label_var = tk.StringVar(value="desativado")
+        self._hotkey_row(auto, "Atalho nova call (dividir gravação)",
+                         self.hotkey_split_var, self.hotkey_split_label_var)
 
         min_row = tk.Frame(auto, bg=_BG)
         min_row.pack(fill="x", pady=6)
@@ -824,7 +819,18 @@ class SettingsWindow:
         self.diar_test_status_var.set(text)
         self._diar_test_lbl.configure(fg=color)
 
-    def _capture_hotkey(self) -> None:
+    def _hotkey_row(self, parent, label: str, var: tk.StringVar, label_var: tk.StringVar) -> None:
+        """Linha de atalho global: rótulo + valor + 'Gravar atalho' + 'limpar' (#38)."""
+        row = tk.Frame(parent, bg=_BG)
+        row.pack(fill="x", pady=6)
+        tk.Label(row, text=label, bg=_BG, fg=PALETTE["text"], font=FONT).pack(side="left")
+        LinkLabel(row, "limpar", lambda: var.set("")).pack(side="right", padx=(8, 0))
+        ModernButton(row, "Gravar atalho", lambda: self._capture_hotkey(var)).pack(side="right", padx=(8, 0))
+        tk.Label(row, textvariable=label_var, bg=PALETTE["field"], fg=PALETTE["text"],
+                 font=("Consolas", 9), padx=10, pady=4).pack(side="right")
+        var.trace_add("write", lambda *a: label_var.set(var.get() or "desativado"))
+
+    def _capture_hotkey(self, var: tk.StringVar) -> None:
         """Janelinha que captura a próxima combinação de teclas (Esc cancela)."""
         cap = tk.Toplevel(self.win)
         cap.title("Gravar atalho")
@@ -857,7 +863,7 @@ class SettingsWindow:
             if parse(spec) is None:
                 info.set(f"'{spec}' não é suportado.\nUse Ctrl/Alt/Shift + letra, número ou F1–F12.")
                 return "break"
-            self.hotkey_var.set(spec)
+            var.set(spec)
             cap.destroy()
             return "break"
 
@@ -1224,6 +1230,7 @@ class SettingsWindow:
         self.max_speakers_var.set(int(getattr(cfg.diarization, "max_speakers", 0)))
         self.min_speakers_var.set(int(getattr(cfg.diarization, "min_speakers", 0)))
         self.hotkey_var.set(cfg.ui.hotkey)
+        self.hotkey_split_var.set(getattr(cfg.ui, "hotkey_split", ""))
         self.min_secs_var.set(int(cfg.detection.min_call_seconds))
         self.split_gap_var.set(int(cfg.detection.split_gap_seconds))
         self.apps_var.set(cfg.detection.apps)
@@ -1321,7 +1328,11 @@ class SettingsWindow:
                 cloud_api_key=self.cloud_api_key_var.get().strip(),
                 cloud_model=self.cloud_model_var.get().strip() or cfg.whisper.cloud_model,
             ),
-            ui=dataclasses.replace(cfg.ui, overlay=self.overlay_var.get(), hotkey=self.hotkey_var.get().strip()),
+            ui=dataclasses.replace(
+                cfg.ui, overlay=self.overlay_var.get(),
+                hotkey=self.hotkey_var.get().strip(),
+                hotkey_split=self.hotkey_split_var.get().strip(),
+            ),
             audio=dataclasses.replace(
                 cfg.audio,
                 mic_device=self._dev_value(self.mic_device_var),

--- a/scriba/tray.py
+++ b/scriba/tray.py
@@ -45,6 +45,8 @@ class Tray:
                 pystray.MenuItem("Configurações", self._open_settings),
                 pystray.MenuItem("Gravar agora", self._start_recording,
                                  visible=lambda item: not self.app.is_recording()),
+                pystray.MenuItem("Nova call (dividir gravação)", self._split_recording,
+                                 visible=lambda item: self.app.is_recording()),
                 pystray.MenuItem("Parar gravação", self._stop_recording,
                                  visible=lambda item: self.app.is_recording()),
                 pystray.MenuItem("Descartar gravação", self._discard_recording,
@@ -83,6 +85,9 @@ class Tray:
 
     def _start_recording(self, icon, item):
         self._bg(self.app.start_recording, "manual")
+
+    def _split_recording(self, icon, item):
+        self._bg(self.app._split_now)  # #38: fecha esta call e começa outra
 
     def _stop_recording(self, icon, item):
         self._bg(self.app.stop_recording, False, True)  # keep=True: intenção explícita

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -94,6 +94,7 @@ class DetectorStateMachineTests(unittest.TestCase):
         self.addCleanup(pt.stop)
         self.events: list[tuple] = []
         self.sessions: dict[str, tuple[int, int]] = {}
+        self.recording = True  # is_recording fake (#38); True = não rearma
 
     def _make(self, **over) -> Detector:
         params = dict(grace_seconds=8.0, poll_seconds=2.0, max_call_hours=4.0, split_gap_seconds=3.0)
@@ -105,6 +106,7 @@ class DetectorStateMachineTests(unittest.TestCase):
             on_grace=lambda: self.events.append(("grace",)),
             on_grace_cancel=lambda: self.events.append(("resume",)),
             on_title=lambda t: self.events.append(("title", t)),
+            is_recording=lambda: self.recording,
         )
         det._mic_sessions = lambda: dict(self.sessions)  # registro controlado
         self.det = det
@@ -364,6 +366,35 @@ class DetectorStateMachineTests(unittest.TestCase):
         self.assertIs(self.det.state, CallState.RECORDING)  # não divide
         self.assertIn("possível nova call sem ciclo", "\n".join(cm.output))
         self.assertEqual(len(self._starts()), 1)
+
+    # -------- rearme do auto-record após ■ (#38, item 5) --------
+
+    def test_rearme_no_ciclo_invisivel_sem_gravacao(self):
+        # usuário deu ■ (call segue, sem gravar); um ciclo novo de mic re-arma
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})       # RECORDING
+        self.recording = False                # ■: para de gravar, call ativa
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll({TEAMS: (_BASE + 50 * _FT, 0)})  # ciclo invisível, título vazio
+        self.assertIn("auto-record re-armado", "\n".join(cm.output))
+        self.assertIn(("started", False), self.events)   # rearmou a call nova
+
+    def test_rearme_na_troca_de_app_sem_gravacao(self):
+        self._make(split_gap_seconds=0.0)     # split off: troca de app não divide
+        self._poll({TEAMS: (_BASE, 0)})
+        self.recording = False
+        with self.assertLogs("scriba.detector", "INFO") as cm:
+            self._poll({TEAMS: (_BASE, _BASE + 100 * _FT), ZOOM: (_BASE + 102 * _FT, 0)})
+        self.assertIn("auto-record re-armado", "\n".join(cm.output))
+        self.assertIn(("started", False), self.events)
+
+    def test_nao_rearma_quando_gravando(self):
+        # gravando normalmente: um ciclo invisível não re-dispara gravação
+        self._make()
+        self._poll({TEAMS: (_BASE, 0)})
+        self.recording = True
+        self._poll({TEAMS: (_BASE + 50 * _FT, 0)})  # ciclo invisível
+        self.assertEqual(len(self._starts()), 1)     # sem rearme: só o start inicial
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fecha #38. Base `main` (o #34 já está mergeado). **Última issue do épico de fusão de calls.**

## Contexto
A divisão automática (#34) é heurística; o usuário SABE o momento da troca de call, e um clique deveria bastar. O fluxo manual de hoje tem duas fraquezas: são duas ações (■ + ⏺), e após ■ com a call ativa o detector fica em RECORDING e `on_call_started` nunca re-dispara - se esquecer o ⏺, a call seguinte **não grava**.

## O que muda
- **Pílula ✂ "nova call"**: botão ao lado de ■/× (glifo + hitbox maior, hover, ocultado no idle); a pílula alarga de 264→304px para acomodar sem colidir com o stepper de participantes.
- **Ação num clique**: `stop_recording(keep=True)` + `start_recording(probe=False)` + toast "Gravação dividida". A parte 1 vai para a fila serial, a parte 2 já grava (sem sonda - os dispositivos estão funcionando).
- **Atalho global** `[ui] hotkey_split` (config + campo na aba de Configurações, reusando o mecanismo do hotkey atual via `_hotkey_row` parametrizado).
- **Menu da bandeja**: "Nova call (dividir gravação)" (visível gravando) - a bandeja é o indicador confiável quando a pílula está oculta.
- **Rearme do auto-record** (item 5, depende de #34): com call ativa, **sem** gravação em andamento (usuário deu ■) e `auto_record`, um ciclo novo de sessão de mic re-inicia a gravação sozinho - fecha a armadilha do "■ e esqueci o ⏺". Via callback `is_recording` no detector, disparado nos ciclos de `_watch_recording` (o `_split` já rearmava implicitamente; um resume "mesma call" de propósito não rearma).

## Bônus
As hitboxes de ■/× agora também somem no modo idle (corrige um clique-fantasma latente onde clicar na área vazia disparava on_stop/on_discard).

## Testes
3 casos novos do rearme (ciclo invisível e troca de app sem gravação re-armam; guard não rearma quando já gravando) - `test_detector` 30/30. Smoke do layout da pílula: ordem ✂<■<×, gap de 10px do stepper, tudo dentro dos limites, idle oculta os botões, callback dispara. Smoke da janela de Configurações com as duas rows de atalho. Suíte sem regressão.