### PR TITLE
fix: auto-update quebrava o launcher (pythonww.exe) ao migrar tkinter->Qt - v1.0.2

### DIFF
--- a/scriba/__init__.py
+++ b/scriba/__init__.py
@@ -1,3 +1,3 @@
 """ScribaDev — gravação e transcrição automática de reuniões do Microsoft Teams."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/scriba/updates.py
+++ b/scriba/updates.py
@@ -165,6 +165,26 @@ def _git(root: Path, *args: str, timeout: float = 120):
                           text=True, timeout=timeout, creationflags=_NO_WINDOW)
 
 
+def _pip_interpreter(executable: str, exists=Path.exists) -> str:
+    """(puro/testável) Interpretador que deve rodar o `pip install` a partir de
+    `executable`. NUNCA devolve o pythonw.exe.
+
+    Por quê: ao (re)instalar, o setuptools/distlib regera o launcher dos gui-scripts
+    (scribadev-tray.exe) derivando o interpretador do exe atual com um replace ingênuo
+    'python' -> 'pythonw'. A partir de 'pythonw.exe' isso vira 'pythonww.exe' (com dois
+    'w'), que não existe — e o app deixa de abrir pelo atalho/bandeja com
+    "Unable to create process using ...\\pythonww.exe". Como a bandeja roda sob o
+    pythonw.exe (sem console), sys.executable É o pythonw.exe e cairíamos exatamente
+    nesse caso. Rodar o pip pelo python.exe irmão gera o launcher correto (-> pythonw.exe).
+    Se o irmão não existir, mantém o original (não inventa caminho)."""
+    py = Path(executable)
+    if py.name.lower() == "pythonw.exe":
+        sibling = py.with_name("python.exe")
+        if exists(sibling):
+            return str(sibling)
+    return executable
+
+
 def apply_git_update() -> tuple[bool, str]:
     """Atualiza uma instalação via git: `git pull --ff-only` + reinstala (pip -e) se o
     pyproject mudou. Retorna (ok, mensagem). Sem git → (False, instrução p/ baixar)."""
@@ -181,7 +201,9 @@ def apply_git_update() -> tuple[bool, str]:
             return (True, "Você já está na versão mais recente.")
         changed = _git(root, "diff", "--name-only", before, after).stdout
         if "pyproject.toml" in changed:  # deps podem ter mudado → reinstala o editable
-            pip = subprocess.run([sys.executable, "-m", "pip", "install", "-e", str(root)],
+            # pelo python.exe (nunca pythonw.exe) p/ não gerar o launcher quebrado
+            # scribadev-tray.exe -> pythonww.exe. Ver _pip_interpreter.
+            pip = subprocess.run([_pip_interpreter(sys.executable), "-m", "pip", "install", "-e", str(root)],
                                  capture_output=True, text=True, timeout=600, creationflags=_NO_WINDOW)
             if pip.returncode != 0:
                 return (False, "Código atualizado, mas a reinstalação de dependências falhou:\n"

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -79,6 +79,29 @@ class ManifestTests(unittest.TestCase):
         self.assertIsNone(up.update_available())  # igual → nada novo
 
 
+class PipInterpreterTests(unittest.TestCase):
+    """Regressão do launcher 'pythonww.exe': o auto-update JAMAIS pode rodar o pip pelo
+    pythonw.exe. Sob a bandeja sys.executable é o pythonw.exe e o distlib gera o
+    scribadev-tray.exe com replace 'python'->'pythonw', virando pythonww.exe (inexistente)
+    -> "Unable to create process using ...\\pythonww.exe" ao abrir pelo atalho."""
+
+    def test_pythonw_cai_no_python_irmao(self):
+        got = up._pip_interpreter(r"C:\ScribaDev\venv\Scripts\pythonw.exe", exists=lambda p: True)
+        self.assertEqual(Path(got).name, "python.exe")
+
+    def test_pythonw_sem_irmao_mantem_original(self):  # não inventa caminho inexistente
+        exe = r"C:\ScribaDev\venv\Scripts\pythonw.exe"
+        self.assertEqual(up._pip_interpreter(exe, exists=lambda p: False), exe)
+
+    def test_python_normal_inalterado(self):
+        exe = r"C:\ScribaDev\venv\Scripts\python.exe"
+        self.assertEqual(up._pip_interpreter(exe, exists=lambda p: True), exe)
+
+    def test_case_insensitive(self):  # Windows: PythonW.EXE também é o caso ruim
+        got = up._pip_interpreter(r"C:\v\Scripts\PythonW.EXE", exists=lambda p: True)
+        self.assertEqual(Path(got).name, "python.exe")
+
+
 class DescribeTests(unittest.TestCase):
     def test_na_tag(self):
         self.assertEqual(up._describe_to_str("v0.3.0", "v0.3.0"), "v0.3.0")


### PR DESCRIPTION
## Problema

Um usuário atualizou do ScribaDev **tkinter** para o **Qt** pelo botão de auto-update in-app e o app parou de abrir:

> Fatal Error in Launcher - Unable to create process using `...\Scripts\pythonww.exe`

(repare o `w` **duplicado** - o correto seria `pythonw.exe`.)

## Causa raiz (reproduzida com pip real)

A bandeja roda sob `pythonw.exe`, então `sys.executable` **é** o `pythonw.exe`. Quando o `pyproject.toml` muda (a migração Qt entrou com o PySide6), `updates.apply_git_update` reinstala o editable com `sys.executable -m pip install -e .` - ou seja, roda o pip **a partir do `pythonw.exe`**.

Ao recriar o launcher de um **gui-script**, o distlib (`_get_alternate_executable`) faz `nome.replace('python', 'pythonw')`. Partindo de `pythonw.exe`, isso gera **`pythonww.exe`** (inexistente). O `scribadev-tray.exe` (usado por atalho/bandeja/autostart) passa a apontar pra ele e falha ao subir o processo.

Instalação via `setup.ps1` nunca teve o bug, porque instala de `python.exe`.

Evidência E2E (venv descartável, pip real):

```
1) install normal (python.exe)      tray -> pythonw.exe     (são)
2) update sob a bandeja (pythonw)   tray -> pythonww.exe    (a quebra)
3) reinstalar de python.exe         tray -> pythonw.exe     (consertado)
```

## Correção

- `updates._pip_interpreter(sys.executable)`: nunca roda o pip pelo `pythonw.exe` - cai no `python.exe` irmão quando ele existe. Usado no `apply_git_update`.
- 4 testes de regressão (`PipInterpreterTests` em `tests/test_updates.py`).
- bump `1.0.1 -> 1.0.2`.
- Suíte completa: **458 verde**.

## Recuperação de quem já quebrou

Reinstalar a partir do `python.exe` regenera os launchers corretos:

```powershell
$py = "$env:LOCALAPPDATA\ScribaDev\venv\Scripts\python.exe"
$repo = & $py -c "import scriba, pathlib; print(pathlib.Path(scriba.__file__).resolve().parent.parent)"
& $py -m pip install -e $repo --force-reinstall --no-deps
& "$env:LOCALAPPDATA\ScribaDev\venv\Scripts\scribadev.exe" shortcut
```

## Atenção

Esta correção protege updates **futuros**. Quem ainda está na **tkinter** e clicar em atualizar vai cair no mesmo buraco (o código que roda o update é o antigo, ainda bugado). Para esses: `git pull` + `setup.ps1`, ou a recuperação acima depois.
