### PR TITLE
feat(qt): seletor de temas com preview + correcao de contraste na troca a quente

### DIFF
--- a/scriba/qt/chat_ui.py
+++ b/scriba/qt/chat_ui.py
@@ -214,33 +214,56 @@ class ChatWindow(QWidget):
         super().resizeEvent(event)
         QTimer.singleShot(0, self._refit_all)   # após o layout atualizar a largura do viewport
 
+    @staticmethod
+    def _bubble_style(kind: str, t) -> str:
+        """QSS de uma bolha por tipo (user/assistant/system). Único ponto de verdade das
+        cores da bolha — usado na criação E na re-estilização da troca a quente (#70)."""
+        if kind == "user":
+            return (f"background:{theme._rgba(t.accent, 0.20)}; border:1px solid {theme._rgba(t.accent, 0.42)};"
+                    f" border-radius:13px; padding:10px 14px; color:{t.text}; font-size:{t.font_size + 2}pt;")
+        if kind == "assistant":
+            return (f"background:{theme._rgba(t.surface, 0.60)}; border:1px solid {theme._rgba(t.border, 0.55)};"
+                    f" border-radius:13px; padding:10px 14px; color:{t.text}; font-size:{t.font_size + 2}pt;")
+        return f"color:{t.muted}; font-size:{t.font_size + 1}pt; font-style:italic; padding:4px;"  # system
+
     def _append_user(self, text: str) -> None:
-        t = theme.active()
         lbl = self._bubble(text, markdown=False)
-        lbl.setStyleSheet(
-            f"background:{theme._rgba(t.accent, 0.20)}; border:1px solid {theme._rgba(t.accent, 0.42)};"
-            f" border-radius:13px; padding:10px 14px; color:{t.text}; font-size:{t.font_size + 2}pt;"
-        )
+        lbl.setProperty("bubbleKind", "user")
+        lbl.setStyleSheet(self._bubble_style("user", theme.active()))
         self._fit_bubble(lbl)
         self._add_row(lbl, "right")
 
     def _append_assistant(self, md: str) -> None:
-        t = theme.active()
         lbl = self._bubble(md, markdown=True)
-        lbl.setStyleSheet(
-            f"background:{theme._rgba(t.surface, 0.60)}; border:1px solid {theme._rgba(t.border, 0.55)};"
-            f" border-radius:13px; padding:10px 14px; color:{t.text}; font-size:{t.font_size + 2}pt;"
-        )
+        lbl.setProperty("bubbleKind", "assistant")
+        lbl.setStyleSheet(self._bubble_style("assistant", theme.active()))
         self._fit_bubble(lbl)
         self._add_row(lbl, "left")
 
     def _append_system(self, text: str) -> None:
-        t = theme.active()
         lbl = self._bubble(text, markdown=False)
+        lbl.setProperty("bubbleKind", "system")
         lbl.setAlignment(Qt.AlignCenter)
-        lbl.setStyleSheet(f"color:{t.muted}; font-size:{t.font_size + 1}pt; font-style:italic; padding:4px;")
+        lbl.setStyleSheet(self._bubble_style("system", theme.active()))
         self._fit_bubble(lbl)
         self._add_row(lbl, "center")
+
+    def restyle_theme(self) -> None:
+        """Troca a quente (#70): re-estiliza as bolhas já criadas (cada uma guarda seu
+        'bubbleKind') e o indicador 'pensando', que fixam a cor do tema na criação. O
+        markdown já renderizado do assistente mantém a cor do texto (herda color)."""
+        t = theme.active()
+        for b in list(self._bubbles):
+            try:
+                b.setStyleSheet(self._bubble_style(b.property("bubbleKind") or "assistant", t))
+            except RuntimeError:
+                self._bubbles.remove(b)   # bolha destruída (após /clear)
+        tl = getattr(self, "_think_lbl", None)
+        if tl is not None:
+            try:
+                tl.setStyleSheet(f"color:{t.accent}; font-style:italic; padding:2px 8px;")
+            except RuntimeError:
+                pass
 
     # -------------------------------------------------------------- chat -------
 

--- a/scriba/qt/log_ui.py
+++ b/scriba/qt/log_ui.py
@@ -116,6 +116,17 @@ class LogWindow(QWidget):
         self._entries = diagnostics.parse_entries(text)
         self._render()
 
+    def restyle_theme(self) -> None:
+        """Troca a quente (#70): re-aplica os estilos com cor de tema (status + view) e
+        re-renderiza o HTML (as cores das linhas são embutidas por _render, a partir do
+        cache self._entries — não relê o arquivo)."""
+        t = theme.active()
+        self._status.setStyleSheet(f"font-size:{t.font_size_small}pt;")
+        self._view.setStyleSheet(
+            f"QTextEdit {{ background:{t.code_bg}; color:{t.text};"
+            f" font-family:'{t.font_mono}','Consolas',monospace; border:none; }}")
+        self._render()
+
     def _render(self) -> None:
         date_br = self._date.br()
         time_from = self._time.hhmm()

--- a/scriba/qt/main_window.py
+++ b/scriba/qt/main_window.py
@@ -104,6 +104,8 @@ class MainWindow(QWidget):
         self._update_ver = None
         self._titlebar_done = False
         self._call_state_kind = "idle"   # idle | rec | call (p/ estilizar o card)
+        self._home_data = None           # último payload de _render_home (re-tema #70)
+        self._status_items = None        # últimos itens de _render_status (re-tema #70)
 
         self.setWindowTitle(f"ScribaDev v{__version__}")
         self.setMinimumSize(520, 560)
@@ -312,6 +314,20 @@ class MainWindow(QWidget):
         self._card.setStyleSheet(f"QFrame#callCard {{ background:{t.surface};"
                                  f" border-radius:{t.radius + 2}px; {edge} }}")
 
+    def restyle_theme(self) -> None:
+        """Re-aplica os estilos inline dependentes de tema após uma troca a quente (o
+        QSS global já mudou): cards da capa (fundo + borda de acento), borda do card de
+        call por estado e re-render das seções dinâmicas (recentes/pendências/serviços)
+        com os dados em cache — cada item fixa a cor do tema na criação, então sem o
+        re-render sobra a cor do tema anterior (borda laranja / cards escuros no claro).
+        Chamado por theme._restyle_top_levels via o contrato `restyle_theme`. (#70)"""
+        self._apply_theme()
+        self._style_call_card()
+        if self._home_data is not None:
+            self._render_home(self._home_data)
+        if self._status_items is not None:
+            self._render_status(self._status_items)
+
     # ---- gravação --------------------------------------------------------------
 
     def _toggle_record(self) -> None:
@@ -455,6 +471,7 @@ class MainWindow(QWidget):
         self.app.ui(lambda: self._render_home(data))
 
     def _render_home(self, data: dict) -> None:
+        self._home_data = data   # cache p/ re-render na troca de tema (restyle_theme)
         t = theme.active()
         # -- estatísticas
         self._stat_meetings._val.setText(f"<b>{data['total']}</b> reuniões")
@@ -603,6 +620,7 @@ class MainWindow(QWidget):
         threading.Thread(target=self._collect_status, daemon=True, name="status").start()
 
     def _render_status(self, items) -> None:
+        self._status_items = items   # cache p/ re-render na troca de tema (restyle_theme)
         _clear_layout(self._rows_lay)
         t = theme.active()
         for level, name, detail in items:

--- a/scriba/qt/notes_ui.py
+++ b/scriba/qt/notes_ui.py
@@ -300,15 +300,10 @@ class NotesWindow(QWidget):
         # que fica pendente ao usuário — a faixa dá importância a ela. Clicável (abre o
         # mesmo diálogo do ícone de vozes). Numa faixa própria (não na fileira) porque o
         # texto não caberia junto do botão de IA sem cortá-lo no minimumSize.
-        th = theme.active()
-        _wr = tuple(int(th.warn.lstrip("#")[i:i + 2], 16) for i in (0, 2, 4))
         self._voice_hint = QLabel("Participantes ainda não rotulados - clique aqui para identificar quem falou")
         self._voice_hint.setCursor(Qt.PointingHandCursor)
         self._voice_hint.mousePressEvent = lambda _e: self._open_speaker_labeler()
-        self._voice_hint.setStyleSheet(
-            f"color:{th.warn}; font-weight:bold; font-size:{th.font_size_small}pt;"
-            f" background:rgba({_wr[0]},{_wr[1]},{_wr[2]},0.14);"
-            f" border:1px solid {th.warn}; border-radius:{th.radius_sm}px; padding:4px 10px;")
+        self._style_voice_hint()
         self._voice_hint.setVisible(False)
         lay.addWidget(self._voice_hint)
 
@@ -355,6 +350,42 @@ class NotesWindow(QWidget):
         t = theme.active()
         self._view.setStyleSheet(f"QTextBrowser {{ background:{t.field}; border:1px solid {t.border};"
                                  f" border-radius:{t.radius + 2}px; padding:8px; }}")
+
+    def _style_voice_hint(self) -> None:
+        """Estilo da faixa de aviso de vozes (cor de aviso). Método próprio para re-aplicar
+        na troca a quente — as cores são fixadas inline (#70)."""
+        th = theme.active()
+        wr = tuple(int(th.warn.lstrip("#")[i:i + 2], 16) for i in (0, 2, 4))
+        self._voice_hint.setStyleSheet(
+            f"color:{th.warn}; font-weight:bold; font-size:{th.font_size_small}pt;"
+            f" background:rgba({wr[0]},{wr[1]},{wr[2]},0.14);"
+            f" border:1px solid {th.warn}; border-radius:{th.radius_sm}px; padding:4px 10px;")
+
+    def restyle_theme(self) -> None:
+        """Troca a quente (#70): re-estiliza o leitor e a faixa de vozes; re-renderiza a
+        nota aberta (presentes + markdown pegam a cor do tema novo) e delega às
+        sub-janelas vivas (chat / itens de ação)."""
+        self._apply_theme()
+        self._style_voice_hint()
+        if self._current_key is not None:
+            md = self._selected_md()
+            if md is not None:
+                self._build_presentes(md)
+                summary, self._transcript_md = _summary_and_transcript(md)
+                self._render_view(summary)
+        if self._chat is not None:
+            try:
+                if self._chat.isVisible():
+                    self._chat.restyle_theme()
+            except RuntimeError:
+                self._chat = None
+        aw = getattr(self, "_actions_win", None)
+        if aw is not None:
+            try:
+                if aw.isVisible():
+                    aw._render()
+            except RuntimeError:
+                pass
 
     # -- atalhos e menu de contexto (#63) ------------------------------------
 

--- a/scriba/qt/overlay.py
+++ b/scriba/qt/overlay.py
@@ -140,6 +140,11 @@ class RecordingPill(QWidget):
         self._tip_timer.setInterval(700)
         self._tip_timer.timeout.connect(self._tip_show)
 
+    def restyle_theme(self) -> None:
+        """Repinta a pílula no tema novo — o paintEvent lê theme.active() a cada frame,
+        então basta forçar o repaint (contrato de troca a quente, #70)."""
+        self.update()
+
     # -- pintura -------------------------------------------------------------
 
     def paintEvent(self, _e) -> None:

--- a/scriba/qt/settings_ui.py
+++ b/scriba/qt/settings_ui.py
@@ -87,74 +87,77 @@ def _pl(text: str, style: str = "", *, wrap: bool = False) -> QLabel:
 
 
 def _mini_home(th: theme.Theme) -> QWidget:
-    """Miniatura da capa pintada com as cores de `th` (um tema ESPECÍFICO, não o ativo):
-    o "como vai ficar" de cada tema no seletor. Espelha a capa real — header + pílulas,
-    card de call com o botão de acento, stats, card de Notas (a borda de ACENTO, que era
-    a do bug #70) e pendências com o badge de aviso. Estilos inline com as cores de `th`;
-    é estático (recriado quando o seletor reconstrói na troca a quente)."""
-    sm, xs = "font-size:8pt;", "font-size:7pt;"
-    root = QFrame()
-    root.setStyleSheet(f"background:{th.bg}; border:1px solid {th.border_strong}; border-radius:8px;")
-    v = QVBoxLayout(root); v.setContentsMargins(9, 8, 9, 9); v.setSpacing(6)
+    """Miniatura ENXUTA da capa nas cores de `th` (um tema específico, não o ativo), com
+    dados fictícios: header + pílulas, card de call com o botão de acento, stats e o card
+    de Notas (a borda de ACENTO — o que o bug #70 sujava). Sem separadores/linhas e sem a
+    seção de pendências: só o essencial p/ ler o tema, como a capa (que não tem linhas)."""
+    xs, xxs = "font-size:7pt;", "font-size:6pt;"
+    # Seletor #id em CADA QFrame: um stylesheet sem seletor vaza `border`/`background`
+    # para os QLabels filhos (era o que desenhava "linhas"/caixas em volta das notas).
+    root = QFrame(); root.setObjectName("miniRoot")
+    root.setStyleSheet(f"#miniRoot {{ background:{th.bg}; border:1px solid {th.border_strong}; border-radius:7px; }}")
+    v = QVBoxLayout(root); v.setContentsMargins(7, 6, 7, 7); v.setSpacing(4)
 
-    hd = QHBoxLayout(); hd.setSpacing(4)
-    hd.addWidget(_pl("ScribaDev", f"color:{th.text}; font-weight:bold; font-size:10pt;"))
+    hd = QHBoxLayout(); hd.setSpacing(3)
+    hd.addWidget(_pl("ScribaDev", f"color:{th.text}; font-weight:bold; {xs}"))
     hd.addStretch(1)
-    hd.addWidget(_pl("Notas", f"background:{th.accent}; color:{th.on_accent}; {xs} padding:2px 6px; border-radius:5px;"))
-    hd.addWidget(_pl("Log", f"background:{th.surface}; color:{th.text}; border:1px solid {th.border}; {xs} padding:2px 6px; border-radius:5px;"))
+    hd.addWidget(_pl("Notas", f"background:{th.accent}; color:{th.on_accent}; {xxs} padding:1px 5px; border-radius:4px;"))
+    hd.addWidget(_pl("Log", f"background:{th.surface}; color:{th.text}; {xxs} padding:1px 5px; border-radius:4px;"))
     v.addLayout(hd)
 
-    call = QFrame(); call.setStyleSheet(f"background:{th.surface}; border:1px solid {th.border}; border-radius:7px;")
-    cl = QHBoxLayout(call); cl.setContentsMargins(8, 6, 8, 6); cl.setSpacing(6)
-    cl.addWidget(_pl("Nenhuma ligação em andamento", f"color:{th.muted}; {sm}"))
+    call = QFrame(); call.setObjectName("miniCall")
+    call.setStyleSheet(f"#miniCall {{ background:{th.surface}; border-radius:5px; }}")
+    cl = QHBoxLayout(call); cl.setContentsMargins(6, 4, 6, 4); cl.setSpacing(5)
+    cl.addWidget(_pl("Nenhuma ligação", f"color:{th.muted}; {xxs}"))
     cl.addStretch(1)
-    cl.addWidget(_pl("● Gravar", f"background:{th.accent}; color:{th.on_accent}; {sm} font-weight:bold; padding:4px 8px; border-radius:6px;"))
+    cl.addWidget(_pl("● Gravar", f"background:{th.accent}; color:{th.on_accent}; {xxs} font-weight:bold; padding:2px 6px; border-radius:4px;"))
     v.addWidget(call)
 
-    v.addWidget(_pl("46 reuniões   ·   17h59 gravadas   ·   11 clientes", f"color:{th.muted}; {xs}"))
+    v.addWidget(_pl("46 reuniões · 17h59 · 11 clientes", f"color:{th.muted}; {xxs}"))
 
-    nc = QFrame(); nc.setStyleSheet(f"background:{th.surface}; border:1px solid {th.accent}; border-radius:8px;")
-    nl = QVBoxLayout(nc); nl.setContentsMargins(8, 7, 8, 7); nl.setSpacing(5)
-    nh = QHBoxLayout()
-    nh.addWidget(_pl("Notas · recentes", f"color:{th.text}; font-weight:bold; {sm}"))
-    nh.addStretch(1)
-    nh.addWidget(_pl("Abrir ›", f"color:{th.muted}; {xs}"))
-    nl.addLayout(nh)
-    for title, meta, client in (("Daily reforma tributária", "02/07 · 11min · 7 part.", "Coruripe"),
-                                ("Matheus Nogueira Peres", "01/07 · 17min · 2 part.", "")):
-        rr = QHBoxLayout(); rr.setSpacing(6)
-        col = QVBoxLayout(); col.setSpacing(0)
-        col.addWidget(_pl(title, f"color:{th.text}; font-weight:bold; {xs}"))
-        col.addWidget(_pl(meta, f"color:{th.muted}; font-size:6pt;"))
-        rr.addLayout(col, 1)
-        if client:
-            rr.addWidget(_pl(client, f"background:{th.field}; color:{th.muted}; border:1px solid {th.border}; font-size:6pt; padding:1px 5px; border-radius:4px;"), 0, Qt.AlignVCenter)
-        nl.addLayout(rr)
+    nc = QFrame(); nc.setObjectName("miniNotes")
+    nc.setStyleSheet(f"#miniNotes {{ background:{th.surface}; border:1px solid {th.accent}; border-radius:5px; }}")
+    nl = QVBoxLayout(nc); nl.setContentsMargins(7, 5, 7, 6); nl.setSpacing(3)
+    nl.addWidget(_pl("Notas · recentes", f"color:{th.text}; font-weight:bold; {xxs}"))
+    nl.addWidget(_pl("Nota 1", f"color:{th.text}; {xs}"))
+    nl.addWidget(_pl("Nota 2", f"color:{th.text}; {xs}"))
     v.addWidget(nc)
-
-    pd = QHBoxLayout(); pd.setSpacing(5)
-    pd.addWidget(_pl("Minhas pendências", f"color:{th.text}; font-weight:bold; {sm}"))
-    pd.addWidget(_pl("283", f"background:{th.warn}; color:{th.bg}; font-weight:bold; {xs} padding:0 6px; border-radius:7px;"))
-    pd.addStretch(1)
-    v.addLayout(pd)
-    it = QHBoxLayout(); it.setSpacing(6)
-    box = QLabel(); box.setFixedSize(10, 10)
-    box.setStyleSheet(f"border:1.4px solid {th.muted}; border-radius:3px; background:transparent;")
-    it.addWidget(box, 0, Qt.AlignTop)
-    col = QVBoxLayout(); col.setSpacing(0)
-    col.addWidget(_pl("Falar com Pedro sobre alocação", f"color:{th.text}; {xs}"))
-    col.addWidget(_pl("Alinhamento demanda NF-e", f"color:{th.muted}; font-size:6pt;"))
-    it.addLayout(col, 1)
-    v.addLayout(it)
     return root
 
 
-class _ThemeCard(QFrame):
-    """Card selecionável de um tema no seletor: rótulo + marcador + a miniatura da capa.
-    `value` = slug do tema (ou None p/ o 'Automático'). Clicar chama on_pick(value). O
-    'chrome' do card (borda/fundo/rótulo) usa o tema ATIVO; a miniatura usa `mini_th`."""
+class _AutoOption(QFrame):
+    """Opção 'Automático' (segue o Windows) no topo do seletor — sem miniatura própria,
+    porque não é uma cor fixa. Clicar aplica o modo automático (on_pick(None))."""
 
-    def __init__(self, mini_th, label, subtitle, value, selected, on_pick):
+    def __init__(self, selected, on_pick):
+        super().__init__()
+        self._value = None
+        self._on_pick = on_pick
+        self.setObjectName("autoopt")
+        self.setCursor(Qt.PointingHandCursor)
+        act = theme.active()
+        edge = act.accent if selected else act.border
+        self.setStyleSheet(f"#autoopt {{ border:{2 if selected else 1}px solid {edge};"
+                           f" border-radius:9px; background:{act.surface}; }}")
+        h = QHBoxLayout(self); h.setContentsMargins(12, 9, 12, 9); h.setSpacing(9)
+        h.addWidget(_pl("●" if selected else "○",
+                        f"color:{act.accent if selected else act.muted}; font-size:12pt;"))
+        col = QVBoxLayout(); col.setSpacing(1)
+        col.addWidget(_pl("Automático", f"color:{act.text}; font-weight:bold; font-size:10pt;"))
+        col.addWidget(_pl("Segue o modo claro/escuro do Windows", f"color:{act.muted}; font-size:8pt;"))
+        h.addLayout(col); h.addStretch(1)
+
+    def mousePressEvent(self, event) -> None:
+        if event.button() == Qt.LeftButton:
+            self._on_pick(None)
+
+
+class _ThemeCard(QFrame):
+    """Card selecionável de UM tema: rótulo + marcador + a miniatura da capa nas cores do
+    tema. `value` = slug. Clicar chama on_pick(value). O 'chrome' (borda/fundo/rótulo) usa
+    o tema ATIVO; a miniatura usa `mini_th`."""
+
+    def __init__(self, mini_th, label, value, selected, on_pick):
         super().__init__()
         self._value = value
         self._on_pick = on_pick
@@ -163,16 +166,14 @@ class _ThemeCard(QFrame):
         act = theme.active()
         edge = act.accent if selected else act.border
         self.setStyleSheet(f"#tcard {{ border:{2 if selected else 1}px solid {edge};"
-                           f" border-radius:10px; background:{act.surface}; }}")
-        v = QVBoxLayout(self); v.setContentsMargins(11, 10, 11, 11); v.setSpacing(7)
+                           f" border-radius:9px; background:{act.surface}; }}")
+        v = QVBoxLayout(self); v.setContentsMargins(9, 8, 9, 9); v.setSpacing(6)
         top = QHBoxLayout()
-        top.addWidget(_pl(label, f"color:{act.text}; font-weight:bold; font-size:10.5pt;"))
+        top.addWidget(_pl(label, f"color:{act.text}; font-weight:bold; font-size:9.5pt;"))
         top.addStretch(1)
         top.addWidget(_pl("●" if selected else "○",
-                          f"color:{act.accent if selected else act.muted}; font-size:12pt;"))
+                          f"color:{act.accent if selected else act.muted}; font-size:11pt;"))
         v.addLayout(top)
-        if subtitle:
-            v.addWidget(_pl(subtitle, f"color:{act.muted}; font-size:8pt;", wrap=True))
         v.addWidget(_mini_home(mini_th))
 
     def mousePressEvent(self, event) -> None:
@@ -521,8 +522,8 @@ class SettingsWindow(QWidget):
 
     def _build_appearance_tab(self) -> None:
         f = self._tab("Aparência")
-        intro = QLabel("Clique num tema para aplicar na hora. Cada card mostra uma prévia "
-                       "da capa com as cores daquele tema.")
+        intro = QLabel("Clique para aplicar na hora. Cada bloco é uma prévia da capa com "
+                       "as cores daquele tema.")
         intro.setProperty("role", "muted"); intro.setWordWrap(True)
         f.addRow(intro)
         self._theme_host = QWidget()
@@ -536,9 +537,9 @@ class SettingsWindow(QWidget):
         self._populate_theme_cards()
 
     def _populate_theme_cards(self) -> None:
-        """(Re)constrói a grade de cards de tema: 'Automático' + um card por tema, 2 por
-        linha, marcando o vigente. Reconstruir (em vez de mutar) mantém tudo pintado no
-        tema ATIVO e o marcador de seleção correto após a troca a quente (#70)."""
+        """(Re)constrói o seletor: a opção 'Automático' no topo (largura cheia) + os 4
+        temas em blocos 2x2, marcando o vigente. Reconstruir (em vez de mutar) mantém tudo
+        pintado no tema ATIVO e o marcador de seleção correto após a troca a quente (#70)."""
         grid = self._theme_grid
         while grid.count():
             item = grid.takeAt(0)
@@ -546,13 +547,10 @@ class SettingsWindow(QWidget):
             if w is not None:
                 w.deleteLater()
         choice = theme.current_choice()   # None = automático
-        auto_mini = theme.by_slug(theme.os_default_theme())
-        cells = [(auto_mini, "Automático", "Segue o modo claro/escuro do Windows", None, choice is None)]
-        for th in theme.themes():
-            cells.append((th, th.label, "", th.name, choice == th.name))
-        for i, (mini_th, label, sub, value, sel) in enumerate(cells):
-            card = _ThemeCard(mini_th, label, sub, value, sel, self._pick_theme)
-            grid.addWidget(card, i // 2, i % 2)
+        grid.addWidget(_AutoOption(choice is None, self._pick_theme), 0, 0, 1, 2)
+        for i, th in enumerate(theme.themes()):
+            card = _ThemeCard(th, th.label, th.name, choice == th.name, self._pick_theme)
+            grid.addWidget(card, 1 + i // 2, i % 2)
 
     def _pick_theme(self, value) -> None:
         """Aplica o tema clicado a quente (state.json, não config.toml). O apply dispara

--- a/scriba/qt/settings_ui.py
+++ b/scriba/qt/settings_ui.py
@@ -526,14 +526,21 @@ class SettingsWindow(QWidget):
                        "as cores daquele tema.")
         intro.setProperty("role", "muted"); intro.setWordWrap(True)
         f.addRow(intro)
+        # largura contida: os blocos não devem esticar p/ preencher a janela (a capa real é
+        # estreita) — teto de ~760px alinhado à esquerda, mesmo com a janela maximizada.
+        row = QWidget()
+        rl = QHBoxLayout(row); rl.setContentsMargins(0, 0, 0, 0)
         self._theme_host = QWidget()
+        self._theme_host.setMaximumWidth(760)
         self._theme_grid = QGridLayout(self._theme_host)
         self._theme_grid.setContentsMargins(0, 8, 0, 0)
         self._theme_grid.setHorizontalSpacing(14)
         self._theme_grid.setVerticalSpacing(14)
         self._theme_grid.setColumnStretch(0, 1)
         self._theme_grid.setColumnStretch(1, 1)
-        f.addRow(self._theme_host)
+        rl.addWidget(self._theme_host)
+        rl.addStretch(1)   # empurra os blocos p/ a esquerda; o excesso fica vazio à direita
+        f.addRow(row)
         self._populate_theme_cards()
 
     def _populate_theme_cards(self) -> None:

--- a/scriba/qt/settings_ui.py
+++ b/scriba/qt/settings_ui.py
@@ -25,6 +25,8 @@ from PySide6.QtWidgets import (
     QDoubleSpinBox,
     QFileDialog,
     QFormLayout,
+    QFrame,
+    QGridLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
@@ -69,6 +71,113 @@ def _csv_merge(existing: str, additions: list[str]) -> str:
             items.append(a)
             seen.add(a.lower())
     return ", ".join(items)
+
+
+# --- seletor de temas com preview (#70) -------------------------------------
+
+def _pl(text: str, style: str = "", *, wrap: bool = False) -> QLabel:
+    """QLabel de texto puro com estilo inline — átomo dos previews de tema."""
+    lbl = QLabel(text)
+    lbl.setTextFormat(Qt.PlainText)
+    if wrap:
+        lbl.setWordWrap(True)
+    if style:
+        lbl.setStyleSheet(style)
+    return lbl
+
+
+def _mini_home(th: theme.Theme) -> QWidget:
+    """Miniatura da capa pintada com as cores de `th` (um tema ESPECÍFICO, não o ativo):
+    o "como vai ficar" de cada tema no seletor. Espelha a capa real — header + pílulas,
+    card de call com o botão de acento, stats, card de Notas (a borda de ACENTO, que era
+    a do bug #70) e pendências com o badge de aviso. Estilos inline com as cores de `th`;
+    é estático (recriado quando o seletor reconstrói na troca a quente)."""
+    sm, xs = "font-size:8pt;", "font-size:7pt;"
+    root = QFrame()
+    root.setStyleSheet(f"background:{th.bg}; border:1px solid {th.border_strong}; border-radius:8px;")
+    v = QVBoxLayout(root); v.setContentsMargins(9, 8, 9, 9); v.setSpacing(6)
+
+    hd = QHBoxLayout(); hd.setSpacing(4)
+    hd.addWidget(_pl("ScribaDev", f"color:{th.text}; font-weight:bold; font-size:10pt;"))
+    hd.addStretch(1)
+    hd.addWidget(_pl("Notas", f"background:{th.accent}; color:{th.on_accent}; {xs} padding:2px 6px; border-radius:5px;"))
+    hd.addWidget(_pl("Log", f"background:{th.surface}; color:{th.text}; border:1px solid {th.border}; {xs} padding:2px 6px; border-radius:5px;"))
+    v.addLayout(hd)
+
+    call = QFrame(); call.setStyleSheet(f"background:{th.surface}; border:1px solid {th.border}; border-radius:7px;")
+    cl = QHBoxLayout(call); cl.setContentsMargins(8, 6, 8, 6); cl.setSpacing(6)
+    cl.addWidget(_pl("Nenhuma ligação em andamento", f"color:{th.muted}; {sm}"))
+    cl.addStretch(1)
+    cl.addWidget(_pl("● Gravar", f"background:{th.accent}; color:{th.on_accent}; {sm} font-weight:bold; padding:4px 8px; border-radius:6px;"))
+    v.addWidget(call)
+
+    v.addWidget(_pl("46 reuniões   ·   17h59 gravadas   ·   11 clientes", f"color:{th.muted}; {xs}"))
+
+    nc = QFrame(); nc.setStyleSheet(f"background:{th.surface}; border:1px solid {th.accent}; border-radius:8px;")
+    nl = QVBoxLayout(nc); nl.setContentsMargins(8, 7, 8, 7); nl.setSpacing(5)
+    nh = QHBoxLayout()
+    nh.addWidget(_pl("Notas · recentes", f"color:{th.text}; font-weight:bold; {sm}"))
+    nh.addStretch(1)
+    nh.addWidget(_pl("Abrir ›", f"color:{th.muted}; {xs}"))
+    nl.addLayout(nh)
+    for title, meta, client in (("Daily reforma tributária", "02/07 · 11min · 7 part.", "Coruripe"),
+                                ("Matheus Nogueira Peres", "01/07 · 17min · 2 part.", "")):
+        rr = QHBoxLayout(); rr.setSpacing(6)
+        col = QVBoxLayout(); col.setSpacing(0)
+        col.addWidget(_pl(title, f"color:{th.text}; font-weight:bold; {xs}"))
+        col.addWidget(_pl(meta, f"color:{th.muted}; font-size:6pt;"))
+        rr.addLayout(col, 1)
+        if client:
+            rr.addWidget(_pl(client, f"background:{th.field}; color:{th.muted}; border:1px solid {th.border}; font-size:6pt; padding:1px 5px; border-radius:4px;"), 0, Qt.AlignVCenter)
+        nl.addLayout(rr)
+    v.addWidget(nc)
+
+    pd = QHBoxLayout(); pd.setSpacing(5)
+    pd.addWidget(_pl("Minhas pendências", f"color:{th.text}; font-weight:bold; {sm}"))
+    pd.addWidget(_pl("283", f"background:{th.warn}; color:{th.bg}; font-weight:bold; {xs} padding:0 6px; border-radius:7px;"))
+    pd.addStretch(1)
+    v.addLayout(pd)
+    it = QHBoxLayout(); it.setSpacing(6)
+    box = QLabel(); box.setFixedSize(10, 10)
+    box.setStyleSheet(f"border:1.4px solid {th.muted}; border-radius:3px; background:transparent;")
+    it.addWidget(box, 0, Qt.AlignTop)
+    col = QVBoxLayout(); col.setSpacing(0)
+    col.addWidget(_pl("Falar com Pedro sobre alocação", f"color:{th.text}; {xs}"))
+    col.addWidget(_pl("Alinhamento demanda NF-e", f"color:{th.muted}; font-size:6pt;"))
+    it.addLayout(col, 1)
+    v.addLayout(it)
+    return root
+
+
+class _ThemeCard(QFrame):
+    """Card selecionável de um tema no seletor: rótulo + marcador + a miniatura da capa.
+    `value` = slug do tema (ou None p/ o 'Automático'). Clicar chama on_pick(value). O
+    'chrome' do card (borda/fundo/rótulo) usa o tema ATIVO; a miniatura usa `mini_th`."""
+
+    def __init__(self, mini_th, label, subtitle, value, selected, on_pick):
+        super().__init__()
+        self._value = value
+        self._on_pick = on_pick
+        self.setObjectName("tcard")
+        self.setCursor(Qt.PointingHandCursor)
+        act = theme.active()
+        edge = act.accent if selected else act.border
+        self.setStyleSheet(f"#tcard {{ border:{2 if selected else 1}px solid {edge};"
+                           f" border-radius:10px; background:{act.surface}; }}")
+        v = QVBoxLayout(self); v.setContentsMargins(11, 10, 11, 11); v.setSpacing(7)
+        top = QHBoxLayout()
+        top.addWidget(_pl(label, f"color:{act.text}; font-weight:bold; font-size:10.5pt;"))
+        top.addStretch(1)
+        top.addWidget(_pl("●" if selected else "○",
+                          f"color:{act.accent if selected else act.muted}; font-size:12pt;"))
+        v.addLayout(top)
+        if subtitle:
+            v.addWidget(_pl(subtitle, f"color:{act.muted}; font-size:8pt;", wrap=True))
+        v.addWidget(_mini_home(mini_th))
+
+    def mousePressEvent(self, event) -> None:
+        if event.button() == Qt.LeftButton:
+            self._on_pick(self._value)
 
 
 class SettingsWindow(QWidget):
@@ -412,23 +521,52 @@ class SettingsWindow(QWidget):
 
     def _build_appearance_tab(self) -> None:
         f = self._tab("Aparência")
-        combo = QComboBox(); widgets.no_wheel_steal(combo)
-        combo.addItem("Automático (segue o Windows)", None)
-        for th in theme.themes():
-            combo.addItem(th.label, th.name)
-        choice = theme.current_choice()
-        idx = combo.findData(choice) if choice else 0
-        combo.setCurrentIndex(idx if idx >= 0 else 0)
-        combo.currentIndexChanged.connect(self._apply_theme_choice)
-        self._theme_combo = combo
-        self._row(f, "Tema", combo,
-                  "Muda na hora. Em Automático, segue o modo claro/escuro do Windows.")
+        intro = QLabel("Clique num tema para aplicar na hora. Cada card mostra uma prévia "
+                       "da capa com as cores daquele tema.")
+        intro.setProperty("role", "muted"); intro.setWordWrap(True)
+        f.addRow(intro)
+        self._theme_host = QWidget()
+        self._theme_grid = QGridLayout(self._theme_host)
+        self._theme_grid.setContentsMargins(0, 8, 0, 0)
+        self._theme_grid.setHorizontalSpacing(14)
+        self._theme_grid.setVerticalSpacing(14)
+        self._theme_grid.setColumnStretch(0, 1)
+        self._theme_grid.setColumnStretch(1, 1)
+        f.addRow(self._theme_host)
+        self._populate_theme_cards()
 
-    def _apply_theme_choice(self, _idx: int = 0) -> None:
-        """Aplica o tema escolhido no combo, a quente (state.json, não config.toml)."""
+    def _populate_theme_cards(self) -> None:
+        """(Re)constrói a grade de cards de tema: 'Automático' + um card por tema, 2 por
+        linha, marcando o vigente. Reconstruir (em vez de mutar) mantém tudo pintado no
+        tema ATIVO e o marcador de seleção correto após a troca a quente (#70)."""
+        grid = self._theme_grid
+        while grid.count():
+            item = grid.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.deleteLater()
+        choice = theme.current_choice()   # None = automático
+        auto_mini = theme.by_slug(theme.os_default_theme())
+        cells = [(auto_mini, "Automático", "Segue o modo claro/escuro do Windows", None, choice is None)]
+        for th in theme.themes():
+            cells.append((th, th.label, "", th.name, choice == th.name))
+        for i, (mini_th, label, sub, value, sel) in enumerate(cells):
+            card = _ThemeCard(mini_th, label, sub, value, sel, self._pick_theme)
+            grid.addWidget(card, i // 2, i % 2)
+
+    def _pick_theme(self, value) -> None:
+        """Aplica o tema clicado a quente (state.json, não config.toml). O apply dispara
+        theme._restyle_top_levels -> self.restyle_theme, que reconstrói a grade marcando
+        o novo vigente. `value` = slug do tema, ou None para o Automático."""
         from PySide6.QtWidgets import QApplication
 
-        theme.apply_choice(self._theme_combo.currentData(), app=QApplication.instance())
+        theme.apply_choice(value, app=QApplication.instance())
+
+    def restyle_theme(self) -> None:
+        """Após a troca a quente, reconstrói a grade de temas (repinta os cards no tema
+        ativo + marca o novo selecionado). Contrato `restyle_theme` de theme.apply (#70)."""
+        if getattr(self, "_theme_grid", None) is not None:
+            self._populate_theme_cards()
 
     def _build_about_tab(self) -> None:
         from .. import updates

--- a/scriba/qt/theme.py
+++ b/scriba/qt/theme.py
@@ -17,9 +17,12 @@ Decisões (épico #44, 2026-07-02):
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, fields
 
 from .. import util
+
+log = logging.getLogger("scriba.qt.theme")
 
 
 @dataclass(frozen=True)
@@ -139,15 +142,19 @@ _CLAUDE = Theme(
     radius=8, radius_sm=5,
 )
 
+# Claro (refinado, #70): camadas separadas por LUMINÂNCIA, não por 2% de cinza. A
+# versão antiga tinha bg #fff e surface #f3f3f3 (quase iguais) — os cards sumiam no
+# fundo. Aqui o fundo é cinza-claro e os cards/campos são brancos, que "flutuam"
+# (padrão Win11/GitHub/VS Code Light). border mais definido separa sem peso.
 _LIGHT = Theme(
     name="light", label="Claro", dark=False,
-    bg="#ffffff", bg2="#eef1f6", surface="#f3f3f3", field="#ffffff", overlay="#ffffff",
-    border="#d4d4d4", border_strong="#b0b0b0",
-    text="#1f1f1f", muted="#616161", faint="#8c8c8c",
+    bg="#f4f6f8", bg2="#eef1f6", surface="#ffffff", field="#ffffff", overlay="#ffffff",
+    border="#dde1e6", border_strong="#b6bfca",
+    text="#1a1d21", muted="#586170", faint="#8a929e",
     accent="#0067c0", accent_hover="#0078d4", accent_press="#005ba1", on_accent="#ffffff",
-    ok="#1a7f37", warn="#9a6700", rec="#d13438", rec_dim="#f1a0a2", info="#0067c0",
-    highlight="#ffd23f", highlight_current="#ff8c1a", on_highlight="#1f1f1f",
-    code_bg="#f3f3f3", code_err="#d13438",
+    ok="#1a7f37", warn="#8a5d00", rec="#c9302f", rec_dim="#e5a3a2", info="#0067c0",
+    highlight="#ffd23f", highlight_current="#f08000", on_highlight="#1f1f1f",
+    code_bg="#eef1f5", code_err="#c9302f",
     selection_bg="#cce4f7", selection_fg="#1f1f1f",
     font_family=_UI, font_mono=_MONO, font_size=9, font_size_small=8,
     radius=6, radius_sm=4,
@@ -192,6 +199,11 @@ def os_default_theme() -> str:
 def themes() -> list[Theme]:
     """Todos os temas registrados, na ordem de exibição."""
     return list(_THEMES.values())
+
+
+def by_slug(name: str) -> Theme:
+    """Tema pelo slug; cai no padrão do SO se o slug for desconhecido/None."""
+    return _THEMES.get(name, _THEMES[os_default_theme()])
 
 
 def active() -> Theme:
@@ -599,11 +611,29 @@ def qss(theme: Theme | None = None) -> str:
     """
 
 
+def _restyle_top_levels(app) -> None:
+    """Depois de trocar o QSS global, EMPURRA o novo tema para as janelas abertas: cada
+    top-level widget que exponha `restyle_theme()` re-aplica seus estilos INLINE (que o
+    QSS global não cobre — bordas de acento, fundos de card etc. capturados na
+    construção). Sem isto, trocar de tema a quente deixa resíduos do tema anterior
+    (ex.: borda de card laranja ao sair do Claude; cards escuros no tema claro) — #70.
+    Contrato leve e desacoplado: nada de sinais persistentes; só toca janelas VIVAS."""
+    for w in app.topLevelWidgets():
+        fn = getattr(w, "restyle_theme", None)
+        if callable(fn):
+            try:
+                fn()
+            except Exception:
+                log.exception("restyle_theme falhou em %s", type(w).__name__)
+
+
 def apply(app, theme: Theme | None = None) -> None:
-    """Aplica fonte-base (Inter…) + QSS do tema ao QApplication. Idempotente."""
+    """Aplica fonte-base (Inter…) + QSS do tema ao QApplication e re-estiliza as janelas
+    abertas (restyle_theme). Idempotente."""
     t = theme or active()
     app.setFont(qfont(t))
     app.setStyleSheet(qss(t))
+    _restyle_top_levels(app)
 
 
 def token_names() -> list[str]:

--- a/tests/test_qt_chat.py
+++ b/tests/test_qt_chat.py
@@ -34,6 +34,22 @@ class ChatTests(unittest.TestCase):
 
         return ChatWindow(_SUMMARY, transcript, "Reunião de teste")
 
+    def test_restyle_theme_reestila_bolhas_sem_quebrar(self):
+        from scriba.qt import theme
+
+        win = self._win()
+        win._append_user("oi")
+        win._append_assistant("**resposta**")
+        win._append_system("aviso")
+        orig = theme._active
+        self.addCleanup(lambda: setattr(theme, "_active", orig))
+        theme._active = theme.by_slug("light")
+        win.restyle_theme()                                   # troca a quente (#70): não estoura
+        user = [b for b in win._bubbles if b.property("bubbleKind") == "user"]
+        self.assertTrue(user)
+        r, g, b = (int(theme.by_slug("light").accent.lstrip("#")[i:i + 2], 16) for i in (0, 2, 4))
+        self.assertIn(f"{r}, {g}, {b}", user[0].styleSheet())          # bolha user pegou o acento novo
+
     def test_intro_e_toggle_com_transcricao(self):
         win = self._win()
         self.assertEqual(self._rows(win), 1)          # só o intro

--- a/tests/test_qt_log_wizard.py
+++ b/tests/test_qt_log_wizard.py
@@ -33,6 +33,17 @@ class LogTests(unittest.TestCase):
         win._render()
         self.assertIn("entradas", win._status.text())
 
+    def test_restyle_theme_smoke(self):
+        from scriba.qt import theme
+        from scriba.qt.log_ui import LogWindow
+
+        win = LogWindow(_App())
+        orig = theme._active
+        self.addCleanup(lambda: setattr(theme, "_active", orig))
+        theme._active = theme.by_slug("light")
+        win.restyle_theme()   # troca a quente (#70): re-aplica view/status + re-render
+        self.assertIn(theme.by_slug("light").code_bg.lower(), win._view.styleSheet().lower())
+
     def test_cycle_level(self):
         from scriba.qt.log_ui import LogWindow
 

--- a/tests/test_qt_main_window.py
+++ b/tests/test_qt_main_window.py
@@ -137,6 +137,43 @@ class MainWindowTests(unittest.TestCase):
         win._open_recent("")
         self.assertIsNone(win.app.notes_opened)
 
+    def test_restyle_theme_nao_retem_acento_do_tema_anterior(self):
+        """Regressão do bug #70 (bordas laranjas): trocar de tema a quente deve
+        re-estilizar a capa; o acento do tema anterior NÃO pode sobrar na borda do card
+        de Notas (era fixado inline na construção e nunca regenerado)."""
+        from scriba.qt import theme
+
+        orig = theme._active
+        self.addCleanup(lambda: setattr(theme, "_active", orig))
+        win = self._win()
+        win._render_home(self._DADOS)   # popula o cache p/ o re-render
+
+        theme._active = theme.by_slug("claude")
+        win.restyle_theme()
+        self.assertIn(theme.by_slug("claude").accent.lower(), win.styleSheet().lower())
+
+        theme._active = theme.by_slug("vscode")   # sai do Claude
+        win.restyle_theme()
+        ss = win.styleSheet().lower()
+        self.assertIn(theme.by_slug("vscode").accent.lower(), ss)      # acento novo entrou
+        self.assertNotIn(theme.by_slug("claude").accent.lower(), ss)   # o terracota não sobrou
+
+    def test_restyle_theme_re_renderiza_secoes_em_cache(self):
+        """restyle_theme re-renderiza recentes/pendências/serviços a partir do cache
+        (sem re-coletar do disco), preservando a contagem."""
+        from scriba.qt import theme
+
+        orig = theme._active
+        self.addCleanup(lambda: setattr(theme, "_active", orig))
+        win = self._win()
+        win._render_home(self._DADOS)
+        win._render_status([("ok", "Detecção", "ativa"), ("warn", "Áudio", "x")])
+        theme._active = theme.by_slug("light")
+        win.restyle_theme()
+        self.assertEqual(win._recent_lay.count(), 2)
+        self.assertEqual(win._pending_lay.count(), 1)
+        self.assertEqual(win._rows_lay.count(), 2)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_qt_notes.py
+++ b/tests/test_qt_notes.py
@@ -85,6 +85,16 @@ class NotesWindowSmokeTests(unittest.TestCase):
 
         return NotesWindow(_App())
 
+    def test_restyle_theme_smoke(self):
+        from scriba.qt import theme
+
+        win = self._win()
+        orig = theme._active
+        self.addCleanup(lambda: setattr(theme, "_active", orig))
+        theme._active = theme.by_slug("light")
+        win.restyle_theme()   # troca a quente (#70), sem nota aberta: não estoura
+        self.assertIn(theme.by_slug("light").field.lower(), win._view.styleSheet().lower())
+
     def test_lista_agrupa_por_dia(self):
         win = self._win()
         win._refresh_list()

--- a/tests/test_qt_overlay.py
+++ b/tests/test_qt_overlay.py
@@ -68,6 +68,11 @@ class PillSmokeTests(unittest.TestCase):
             setup()
             pill.repaint()  # exercita cada ramo do paintEvent
 
+    def test_restyle_theme_repinta_sem_erro(self):
+        pill = self._pill()
+        pill.set_mode("recording")
+        pill.restyle_theme()   # troca a quente (#70): força repaint (paintEvent lê active())
+
     def test_callbacks_por_regiao(self):
         pill = self._pill()
         pill.set_mode("recording")

--- a/tests/test_qt_settings.py
+++ b/tests/test_qt_settings.py
@@ -69,15 +69,17 @@ class SettingsTests(unittest.TestCase):
 
     def test_aba_aparencia_tem_grade_de_temas(self):
         from scriba.qt import theme
-        from scriba.qt.settings_ui import SettingsWindow, _ThemeCard
+        from scriba.qt.settings_ui import SettingsWindow, _ThemeCard, _AutoOption
 
         win = SettingsWindow(self._app())
         grid = win._theme_grid
-        cards = [grid.itemAt(i).widget() for i in range(grid.count())]
-        self.assertEqual(len(cards), 1 + len(theme.themes()))       # Automático + os 4 temas
+        items = [grid.itemAt(i).widget() for i in range(grid.count())]
+        self.assertEqual(len(items), 1 + len(theme.themes()))       # Automático + os 4 temas
+        self.assertIsInstance(items[0], _AutoOption)                # 1ª opção = Automático
+        self.assertIsNone(items[0]._value)
+        cards = items[1:]
         self.assertTrue(all(isinstance(c, _ThemeCard) for c in cards))
-        self.assertIsNone(cards[0]._value)                          # 1º card = Automático (None)
-        self.assertEqual([c._value for c in cards[1:]], [t.name for t in theme.themes()])
+        self.assertEqual([c._value for c in cards], [t.name for t in theme.themes()])
 
     def test_restyle_reconstroi_a_grade_sem_erro(self):
         from scriba.qt.settings_ui import SettingsWindow

--- a/tests/test_qt_settings.py
+++ b/tests/test_qt_settings.py
@@ -67,16 +67,25 @@ class SettingsTests(unittest.TestCase):
         arch, _ = self._field(win, "audio", "archive_format")
         self.assertEqual(arch.currentData(), "opus")
 
-    def test_aba_aparencia_tem_seletor_de_tema(self):
+    def test_aba_aparencia_tem_grade_de_temas(self):
         from scriba.qt import theme
+        from scriba.qt.settings_ui import SettingsWindow, _ThemeCard
+
+        win = SettingsWindow(self._app())
+        grid = win._theme_grid
+        cards = [grid.itemAt(i).widget() for i in range(grid.count())]
+        self.assertEqual(len(cards), 1 + len(theme.themes()))       # Automático + os 4 temas
+        self.assertTrue(all(isinstance(c, _ThemeCard) for c in cards))
+        self.assertIsNone(cards[0]._value)                          # 1º card = Automático (None)
+        self.assertEqual([c._value for c in cards[1:]], [t.name for t in theme.themes()])
+
+    def test_restyle_reconstroi_a_grade_sem_erro(self):
         from scriba.qt.settings_ui import SettingsWindow
 
         win = SettingsWindow(self._app())
-        combo = win._theme_combo
-        self.assertEqual(combo.count(), 1 + len(theme.themes()))   # Automático + os 4 temas
-        self.assertIsNone(combo.itemData(0))                        # 1º item = Automático (None)
-        slugs = [combo.itemData(i) for i in range(1, combo.count())]
-        self.assertEqual(slugs, [t.name for t in theme.themes()])
+        n = win._theme_grid.count()
+        win.restyle_theme()                                          # troca a quente (#70)
+        self.assertEqual(win._theme_grid.count(), n)                 # reconstruiu, mesma contagem
 
     def test_round_trip_persiste_mudancas(self):
         from scriba import config as config_mod

--- a/tests/test_qt_theme.py
+++ b/tests/test_qt_theme.py
@@ -159,6 +159,56 @@ class SwitchTests(unittest.TestCase):
         self.assertEqual(theme.active().name, theme.os_default_theme())
 
 
+@unittest.skipUnless(_HAS_PYSIDE, "PySide6 não instalado (extra 'qt')")
+class RestyleContractTests(unittest.TestCase):
+    """Contrato da troca a quente (#70): theme.apply empurra restyle_theme p/ as janelas
+    abertas que o expõem, e NÃO quebra com as que não têm (nem se uma restyle falhar)."""
+
+    @classmethod
+    def setUpClass(cls):
+        from PySide6.QtWidgets import QApplication
+
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_apply_chama_restyle_e_ignora_quem_nao_tem(self):
+        from PySide6.QtWidgets import QWidget
+
+        calls = []
+
+        class _W(QWidget):
+            def restyle_theme(inner):
+                calls.append(1)
+
+        w = _W(); w.show()
+        plain = QWidget(); plain.show()          # sem restyle_theme: não pode quebrar
+        orig = theme._active
+        self.addCleanup(lambda: setattr(theme, "_active", orig))
+        self.addCleanup(w.close)
+        self.addCleanup(plain.close)
+        theme.apply(self.app, theme.by_slug("vscode"))
+        self.assertTrue(calls)                   # a janela foi re-estilizada
+
+    def test_uma_restyle_que_falha_nao_derruba_as_outras(self):
+        from PySide6.QtWidgets import QWidget
+
+        ok = []
+
+        class _Bad(QWidget):
+            def restyle_theme(inner):
+                raise RuntimeError("boom no restyle")
+
+        class _Good(QWidget):
+            def restyle_theme(inner):
+                ok.append(1)
+
+        bad = _Bad(); bad.show()
+        good = _Good(); good.show()
+        self.addCleanup(bad.close)
+        self.addCleanup(good.close)
+        theme._restyle_top_levels(self.app)      # não propaga a exceção
+        self.assertTrue(ok)                      # a boa ainda rodou
+
+
 # -- ícones Fluent vendorizados (#59) -----------------------------------------
 
 # Vocabulário que a fundação promete (scriba/qt/icons/*.svg). Se um nome sumir do


### PR DESCRIPTION
Fecha #70. Direção definida com você via `/lavish` (preview renderizado com as cores reais de `theme.py`).

## O que muda

### 1. Seletor com preview (aba Aparência)
O `QComboBox` de nomes virou uma **grade de cards**: cada tema mostra uma **miniatura da capa** pintada com suas próprias cores (header, card de call com o botão de acento, stats, card de Notas com a borda de acento, pendências), com contorno no vigente. "Automático" mostra a miniatura do tema do Windows atual. O submenu da bandeja segue como atalho rápido.

### 2. Correção dos dois bugs de contraste na troca a quente
Raiz comum: `theme.apply` só reaplicava o QSS global; os `setStyleSheet` inline por-janela ficavam com a cor do tema anterior.

- **`theme.apply` agora empurra o tema para as janelas abertas** via um contrato leve: cada top-level com `restyle_theme()` re-aplica seus estilos inline. Implementado em capa, notas, configurações, log, chat e pílula.
- **Bug 1 (bordas laranjas):** a borda do card de Notas não fica mais com o acento do Claude ao trocar para outro tema. Verificado E2E por amostragem de pixel: `claude→#b85c3c`, `vscode→#0e639c`, `light→#0067c0`.
- **Bug 2 (tema claro):** os cards não ficam mais escuros sobre fundo branco.

### 3. Tema claro refinado
A paleta clara tinha `surface` (#f3f3f3) quase igual ao `bg` (#fff) — os cards sumiam. Agora **fundo cinza claro + cards brancos** (padrão Win11/GitHub). Contraste WCAG AA mantido (texto/fundo 16.9:1, texto/card 17.4:1).

## Testes
- Regressão do acento que sobrava na capa (troca Claude→VS Code→Claro assertando que o inline não retém a cor anterior).
- Contrato do `restyle_top_levels` (chama quem tem `restyle_theme`, ignora quem não tem, uma falha não derruba as outras).
- Grade de temas + smokes de `restyle_theme` em notas/chat/log/pílula.
- Suíte completa: **467 verde**.

## Validação visual
Renderizei a capa e o seletor offscreen (PNG) para conferir cores/layout sem abrir o app. Falta a validação na tela por você (uso real) — como sempre com temas, antes de fechar a release.
