### PR TITLE
Épico #75: sistema de pendências - hub completo (#76-#80, #82)

### DIFF
--- a/scriba/config.py
+++ b/scriba/config.py
@@ -209,6 +209,7 @@ class Ui:
     overlay: bool = True
     hotkey: str = ""
     hotkey_split: str = ""  # atalho global "nova call" / dividir a gravação (#38)
+    pending_window_days: int = 30  # recorte da capa: só pendências dos últimos N dias contam (0 = tudo)
 
 
 @dataclass(frozen=True)
@@ -367,6 +368,7 @@ timeout_seconds = {_n(s.timeout_seconds)}
 overlay = {_b(u.overlay)}           # pílula flutuante durante a gravação
 hotkey = {_s(u.hotkey)}              # atalho global gravar/parar (ex.: "ctrl+alt+r"); vazio desativa
 hotkey_split = {_s(u.hotkey_split)}        # atalho global "nova call" (divide a gravação, #38); vazio desativa
+pending_window_days = {_n(u.pending_window_days)}       # capa: só pendências de reuniões dos últimos N dias contam (0 = sem recorte)
 
 [output]
 # Pasta para onde o notas.md final é copiado. Vazio = Documentos\\ScribaDev

--- a/scriba/main.py
+++ b/scriba/main.py
@@ -94,6 +94,7 @@ class ScribaApp:
         self.tray = None
         self.settings = None
         self.notes_win = None
+        self.action_hub = None   # hub de pendências (#78), instância única
         self.wizard_win = None
         self.log_win = None
         self.main_win = None
@@ -401,6 +402,27 @@ class ScribaApp:
         self.notes_win.show()
         if note_path is not None:
             self.notes_win.reveal_note(note_path)
+
+    def show_action_hub(self, note_path=None) -> None:
+        """Abre o hub de pendências (#78/#82), instância única, chamável de qualquer thread.
+        Se `note_path` for dado, posiciona o hub na reunião correspondente."""
+        self.ui(lambda: self._open_action_hub_ui(note_path))
+
+    def _open_action_hub_ui(self, note_path=None) -> None:
+        if self.notes_win is None:
+            from .qt.notes_ui import NotesWindow
+
+            self.notes_win = NotesWindow(self)   # o hub reusa collect + navegação de Notas
+        if self.action_hub is None:
+            from .qt.notes_ui import _ActionItemsWindow
+
+            self.action_hub = _ActionItemsWindow(
+                self, self.notes_win._collect_action_groups,
+                self.notes_win.reveal_note_at_section)
+        self.action_hub.refresh()
+        self.action_hub.show()
+        if note_path is not None:
+            self.action_hub.focus_meeting(note_path)
 
     def show_log(self) -> None:
         """Abre a janela de Log/diagnóstico (chamável de qualquer thread)."""

--- a/scriba/meetings_index.py
+++ b/scriba/meetings_index.py
@@ -24,7 +24,7 @@ from . import util
 log = logging.getLogger("scriba.meetings_index")
 
 DB_PATH = util.APP_DIR / "index.db"
-SCHEMA_VERSION = 2  # v2 (#11): transcrição agora também entra no FTS
+SCHEMA_VERSION = 3  # v3 (#76): pendências (action items) viram snapshot no índice
 
 # Separa o resumo da transcrição completa no notas.md. AMBOS entram no FTS (v2/#11):
 # o resumo na coluna `body`, a transcrição na coluna `transcript` — assim a busca do
@@ -62,6 +62,21 @@ _DDL = (
     )""",
     "CREATE INDEX IF NOT EXISTS ix_part_name    ON participants(name)",
     "CREATE INDEX IF NOT EXISTS ix_part_meeting ON participants(meeting_id)",
+    # Pendências (#76): snapshot DERIVADO da seção "## Pendências e Ações" de cada nota,
+    # cruzado com o `.actions.json` (fonte da verdade do estado). `state` já nasce string
+    # p/ acomodar os estados futuros do épico (open/done/dismissed/archived) sem novo bump;
+    # aqui só `open` e `done` são populados (o .actions.json de hoje só distingue feito).
+    # `position` = ordem do item na nota (p/ listar na mesma sequência).
+    """CREATE TABLE IF NOT EXISTS action_items (
+        meeting_id INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
+        key        TEXT NOT NULL,
+        label      TEXT,
+        text       TEXT,
+        state      TEXT NOT NULL DEFAULT 'open',
+        position   INTEGER
+    )""",
+    "CREATE INDEX IF NOT EXISTS ix_action_meeting ON action_items(meeting_id)",
+    "CREATE INDEX IF NOT EXISTS ix_action_state   ON action_items(state)",
     # FTS5 standalone (guarda o próprio texto: simples e robusto p/ delete/rebuild).
     # rowid == meetings.id, mantido à mão no insert/delete. `body` = resumo,
     # `transcript` = transcrição completa (v2/#11) — MATCH sem coluna busca em todas.
@@ -87,7 +102,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         # índice é reconstruível: schema divergente = dropa tudo e recria vazio
         # (reindexar repopula a partir das pastas — sem migração de dados dolorosa).
         log.warning("index.db schema v%s != v%s — recriando (reindexe p/ repopular)", version, SCHEMA_VERSION)
-        for tbl in ("meetings_fts", "participants", "meetings"):
+        for tbl in ("meetings_fts", "action_items", "participants", "meetings"):
             conn.execute(f"DROP TABLE IF EXISTS {tbl}")
         version = 0
     for ddl in _DDL:
@@ -148,6 +163,14 @@ def _extract(folder: Path) -> dict | None:
     presentes, mencionados = notes.parse_participants(md) if md else ({}, [])
     parts = [{"name": n, "role": (r or "").strip(), "kind": "present"} for n, r in presentes.items()]
     parts += [{"name": n, "role": "", "kind": "mentioned"} for n in mencionados]
+    # Pendências (#76): itens da nota + estado do sidecar. `state` derivado do
+    # `.actions.json` (fonte da verdade): item marcado → 'done', senão 'open'.
+    action_state = notes.load_action_state(folder) if md else {}
+    action_items = [
+        {"key": it["key"], "label": it["label"], "text": it["text"],
+         "state": "done" if action_state.get(it["key"]) else "open"}
+        for it in (notes.parse_action_items(md) if md else [])
+    ]
     dur = meta.get("duration_seconds")
     return {
         "folder": str(folder),
@@ -160,6 +183,7 @@ def _extract(folder: Path) -> dict | None:
         "meeting_title": (meta.get("meeting_title") or "").strip(),
         "export_path": meta.get("export_path") or "",
         "participants": parts,
+        "action_items": action_items,
         "body": _summary_body(md),
         "transcript": _transcript_text(md),
     }
@@ -187,6 +211,14 @@ def _upsert(conn: sqlite3.Connection, rec: dict) -> int:
         conn.executemany(
             "INSERT INTO participants (meeting_id, name, role, kind) VALUES (?,?,?,?)",
             [(mid, p["name"], p["role"], p["kind"]) for p in rec["participants"]],
+        )
+    action_items = rec.get("action_items") or []
+    if action_items:
+        conn.executemany(
+            "INSERT INTO action_items (meeting_id, key, label, text, state, position)"
+            " VALUES (?,?,?,?,?,?)",
+            [(mid, a["key"], a["label"], a["text"], a["state"], i)
+             for i, a in enumerate(action_items)],
         )
     names = " ".join(p["name"] for p in rec["participants"])
     conn.execute(
@@ -245,6 +277,30 @@ def remove_meeting(folder) -> bool:
         return False
 
 
+def set_action_state(folder, key: str, state: str) -> bool:
+    """Atualiza no índice o `state` de UMA pendência (snapshot), sem reindexar a nota.
+    Chamado por `notes.set_action_done` logo após gravar o `.actions.json` (que segue
+    a FONTE DA VERDADE do estado), p/ capa/hub refletirem o clique na hora. NUNCA levanta
+    (só loga e devolve False): o índice é derivado, um erro aqui não pode quebrar a UI —
+    o próximo reindex reconstrói o snapshot a partir do `.actions.json` de qualquer forma.
+    Devolve True se a linha existia e foi atualizada."""
+    try:
+        conn = _connect()
+        try:
+            with conn:
+                cur = conn.execute(
+                    "UPDATE action_items SET state = ? WHERE key = ? AND meeting_id = "
+                    "(SELECT id FROM meetings WHERE folder = ?)",
+                    (state, key, str(folder)),
+                )
+            return cur.rowcount > 0
+        finally:
+            conn.close()
+    except Exception:
+        log.exception("falha ao atualizar estado da pendência %s em %s", key, folder)
+        return False
+
+
 def mark_deleted(folder) -> None:
     """Exclusão pela UI (#16) MANTENDO o áudio: tira a reunião do índice agora E deixa um
     tombstone `.deleted` na pasta para o reindex não trazê-la de volta. O áudio + meta
@@ -273,6 +329,7 @@ def reindex(recordings_dir=None) -> int:
     try:
         with conn:
             conn.execute("DELETE FROM meetings_fts")
+            conn.execute("DELETE FROM action_items")
             conn.execute("DELETE FROM participants")
             conn.execute("DELETE FROM meetings")
         for meta_path in sorted(recordings_dir.rglob("meta.json")):
@@ -384,5 +441,76 @@ def count() -> int:
     conn = _connect()
     try:
         return conn.execute("SELECT COUNT(*) FROM meetings").fetchone()[0]
+    finally:
+        conn.close()
+
+
+# -- pendências (action items): consulta do snapshot (#76) ------------------
+
+def _action_filters(state=None, states=None, since=None, until=None, client=None,
+                    folder=None) -> tuple[list[str], list]:
+    """Cláusulas WHERE + params comuns a `action_counts` e `list_action_items`.
+    `a` = action_items, `m` = meetings (o JOIN é montado por quem chama)."""
+    where, params = [], []
+    st = list(states) if states else ([state] if state else [])
+    if st:
+        where.append("a.state IN (%s)" % ",".join("?" * len(st)))
+        params += [str(s) for s in st]
+    if since:
+        where.append("m.started_at >= ?")
+        params.append(str(since))
+    if until:
+        where.append("m.started_at <= ?")
+        params.append(_until_bound(until))
+    if client:
+        where.append("m.client LIKE ?")
+        params.append(f"%{client}%")
+    if folder:
+        where.append("m.folder = ?")
+        params.append(str(folder))
+    return where, params
+
+
+def action_counts(since=None, until=None, client=None) -> dict:
+    """Contagem de pendências POR ESTADO (ex.: `{'open': 5, 'done': 3}`), aplicando o
+    recorte temporal (`since`/`until` em `meetings.started_at`) e por `client`. Base do
+    badge "N ativas" da capa (A4) e dos totais do hub (A3) — barato, sem re-parsear `.md`.
+    Estados ausentes simplesmente não aparecem no dict (use `.get(estado, 0)`)."""
+    conn = _connect()
+    try:
+        where, params = _action_filters(since=since, until=until, client=client)
+        sql = ("SELECT a.state AS state, COUNT(*) AS n FROM action_items a "
+               "JOIN meetings m ON m.id = a.meeting_id")
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " GROUP BY a.state"
+        return {r["state"]: r["n"] for r in conn.execute(sql, params).fetchall()}
+    finally:
+        conn.close()
+
+
+def list_action_items(state=None, states=None, since=None, until=None, client=None,
+                      folder=None, limit=500) -> list[dict]:
+    """Pendências do índice já com o contexto da reunião (p/ o hub/capa abrirem a nota
+    certa sem ler disco). Substitui o papel de `notes.open_action_items` (que re-parseava
+    cada `.md`). Filtros combinam (AND): `state` (um) ou `states` (vários), recorte por
+    `since`/`until` em `started_at`, `client` (parcial), `folder` (exato).
+
+    Cada item volta com `key`/`label`/`text`/`state`/`position` + o contexto da reunião
+    (`meeting_id`, `folder`, `export_path`, `title`, `meeting_title`, `client`,
+    `started_at`). Ordenado por reunião mais recente primeiro, itens na ordem da nota."""
+    conn = _connect()
+    try:
+        where, params = _action_filters(state=state, states=states, since=since,
+                                        until=until, client=client, folder=folder)
+        sql = ("SELECT a.key, a.label, a.text, a.state, a.position, "
+               "m.id AS meeting_id, m.folder, m.export_path, m.title, "
+               "m.meeting_title, m.client, m.started_at "
+               "FROM action_items a JOIN meetings m ON m.id = a.meeting_id")
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY m.started_at DESC, a.position ASC LIMIT ?"
+        params.append(int(limit))
+        return [dict(r) for r in conn.execute(sql, params).fetchall()]
     finally:
         conn.close()

--- a/scriba/meetings_index.py
+++ b/scriba/meetings_index.py
@@ -164,11 +164,12 @@ def _extract(folder: Path) -> dict | None:
     parts = [{"name": n, "role": (r or "").strip(), "kind": "present"} for n, r in presentes.items()]
     parts += [{"name": n, "role": "", "kind": "mentioned"} for n in mencionados]
     # Pendências (#76): itens da nota + estado do sidecar. `state` derivado do
-    # `.actions.json` (fonte da verdade): item marcado → 'done', senão 'open'.
+    # `.actions.json` (fonte da verdade), já normalizado p/ estado nomeado (#77):
+    # open/done/dismissed/archived; ausente = 'open'.
     action_state = notes.load_action_state(folder) if md else {}
     action_items = [
         {"key": it["key"], "label": it["label"], "text": it["text"],
-         "state": "done" if action_state.get(it["key"]) else "open"}
+         "state": action_state.get(it["key"], "open")}
         for it in (notes.parse_action_items(md) if md else [])
     ]
     dur = meta.get("duration_seconds")

--- a/scriba/notes.py
+++ b/scriba/notes.py
@@ -917,6 +917,7 @@ def open_action_items(meetings: list[dict]) -> list[dict]:
                 "client": (m.get("client") or "").strip(),
                 "note_path": exp,
                 "folder": folder,
+                "started_at": (m.get("started_at") or "").strip(),
             })
     return out
 

--- a/scriba/notes.py
+++ b/scriba/notes.py
@@ -815,38 +815,72 @@ def parse_action_items(md: str) -> list[dict]:
     return items
 
 
+# Estados nomeados de uma pendência (#77). "open" NÃO é gravado no sidecar — ausência
+# da chave já significa aberta, mantendo o `.actions.json` enxuto. Os demais (recuperáveis)
+# ficam persistidos. O snapshot no índice (#76) espelha estes mesmos estados.
+ACTION_STATES = ("open", "done", "dismissed", "archived")
+
+
+def _normalize_action_state(value) -> str:
+    """Normaliza um valor do `.actions.json` para um estado nomeado (retrocompat de leitura).
+    Formato legado bool: `true` -> 'done', `false`/ausente -> 'open'. String conhecida passa
+    direto; qualquer outra coisa (desconhecida/corrompida) -> 'open' (defensivo)."""
+    if value is True:
+        return "done"
+    if isinstance(value, str) and value in ACTION_STATES:
+        return value
+    return "open"
+
+
 def load_action_state(folder: Path) -> dict:
-    """Estado dos itens resolvidos: {item_key: True}. Sidecar `.actions.json` na pasta da
-    gravação — NÃO reescreve o .md. {} se ausente/ilegível."""
+    """Estado nomeado dos itens: `{item_key: 'done'|'dismissed'|'archived'}`. Sidecar
+    `.actions.json` na pasta da gravação — NÃO reescreve o .md. Itens `open` (ausentes ou
+    normalizados p/ aberto) NÃO entram no dict. Lê o formato legado `{key: true}` como
+    `done` (retrocompat, sem migração destrutiva). {} se ausente/ilegível."""
     try:
         data = json.loads((Path(folder) / ".actions.json").read_text(encoding="utf-8"))
-        return data if isinstance(data, dict) else {}
     except (OSError, ValueError):
         return {}
+    if not isinstance(data, dict):
+        return {}
+    out = {}
+    for k, v in data.items():
+        st = _normalize_action_state(v)
+        if st != "open":
+            out[k] = st
+    return out
 
 
-def set_action_done(folder: Path, key: str, done: bool) -> None:
-    """Marca/desmarca um item como resolvido no `.actions.json` da pasta (escrita atômica)."""
+def set_action_state(folder: Path, key: str, state: str) -> None:
+    """Grava o estado nomeado de UM item no `.actions.json` (escrita atômica). `state ==
+    'open'` REMOVE a chave (ausência = aberta), mantendo o arquivo enxuto. Ponto único de
+    escrita do estado: também sincroniza o snapshot do índice (#76) p/ capa/hub refletirem
+    na hora, sem reindex. O `.actions.json` é a FONTE DA VERDADE; o índice é derivado e
+    resiliente (set_action_state do índice nunca levanta) — o próximo reindex reconcilia."""
     folder = Path(folder)
-    state = load_action_state(folder)
-    if done:
-        state[key] = True
+    if state not in ACTION_STATES:
+        state = "open"
+    data = load_action_state(folder)
+    if state == "open":
+        data.pop(key, None)
     else:
-        state.pop(key, None)
+        data[key] = state
     try:
         folder.mkdir(parents=True, exist_ok=True)
-        util.atomic_write_text(folder / ".actions.json", json.dumps(state, ensure_ascii=False))
+        util.atomic_write_text(folder / ".actions.json", json.dumps(data, ensure_ascii=False))
     except OSError as e:
         import logging
 
         logging.getLogger("scriba.notes").warning("falha ao salvar .actions.json em %s: %s", folder, e)
-    # Reflete o clique no snapshot do índice (#76) p/ capa/hub atualizarem sem reindex.
-    # O `.actions.json` acima é a fonte da verdade; o índice é derivado e resiliente
-    # (set_action_state nunca levanta), então isto é best-effort e roda mesmo se o
-    # .actions.json falhou — o próximo reindex reconcilia os dois de qualquer forma.
     from . import meetings_index  # lazy: evita ciclo (meetings_index importa notes)
 
-    meetings_index.set_action_state(folder, key, "done" if done else "open")
+    meetings_index.set_action_state(folder, key, state)
+
+
+def set_action_done(folder: Path, key: str, done: bool) -> None:
+    """Marca/desmarca um item como resolvido. Wrapper fino sobre `set_action_state`
+    (`done` -> 'done', desmarcar -> 'open') p/ não quebrar os call sites existentes."""
+    set_action_state(folder, key, "done" if done else "open")
 
 
 def open_action_items(meetings: list[dict]) -> list[dict]:
@@ -854,11 +888,12 @@ def open_action_items(meetings: list[dict]) -> list[dict]:
 
     `meetings` é uma lista de reuniões como `meetings_index.search` devolve (cada
     dict com pelo menos `export_path` e `folder`). Para cada uma, lê o .md
-    exportado, extrai os itens (`parse_action_items`) e descarta os já resolvidos
-    no `.actions.json` da pasta (`load_action_state`). Cada item volta enriquecido
-    com o contexto da reunião (`title`, `client`, `note_path`) para a UI abrir a
-    nota certa. Preserva a ordem de entrada (as reuniões já vêm da mais recente
-    para a mais antiga)."""
+    exportado, extrai os itens (`parse_action_items`) e mantém só os `open` — itens
+    `done`/`dismissed`/`archived` no `.actions.json` saem do contador de ativas
+    (`load_action_state`). Cada item volta enriquecido com o contexto da reunião
+    (`title`, `client`, `note_path`, `folder`) para a UI abrir a nota certa e poder
+    marcar/dispensar (`set_action_state` precisa de `folder`+`key`). Preserva a ordem
+    de entrada (as reuniões já vêm da mais recente para a mais antiga)."""
     out: list[dict] = []
     for m in meetings:
         exp = (m.get("export_path") or "").strip()
@@ -874,15 +909,59 @@ def open_action_items(meetings: list[dict]) -> list[dict]:
             continue
         state = load_action_state(Path(folder))
         for it in items:
-            if state.get(it["key"]):
+            if state.get(it["key"], "open") != "open":
                 continue
             out.append({
                 **it,
                 "title": (m.get("title") or m.get("meeting_title") or "").strip(),
                 "client": (m.get("client") or "").strip(),
                 "note_path": exp,
+                "folder": folder,
             })
     return out
+
+
+def archive_old_action_items(meetings: list[dict], older_than_days: int = 30,
+                             reference_date=None) -> int:
+    """Arquiva em massa (`state='archived'`) todos os itens AINDA ABERTOS de reuniões com
+    mais de `older_than_days` dias — zera o backlog antigo de uma vez sem tocar nos `.md`.
+    A idade conta pela DATA DA REUNIÃO (`started_at`), não pela edição do item. Reunião
+    sem `started_at` válido conta como ANTIGA (degradação segura: vai para o backlog).
+    NÃO mexe em itens já `done`/`dismissed`/`archived` nem em reuniões recentes. Função
+    pura/testável (a UI só orquestra + confirma). Devolve quantos itens foram arquivados.
+
+    `meetings` = lista como `meetings_index.search` devolve (precisa de `export_path`,
+    `folder`, `started_at`). `older_than_days <= 0` = sem recorte: não arquiva nada."""
+    from datetime import datetime, timedelta
+
+    if older_than_days <= 0:
+        return 0
+    now = reference_date or datetime.now()
+    cutoff = now - timedelta(days=older_than_days)
+    n = 0
+    for m in meetings:
+        exp = (m.get("export_path") or "").strip()
+        folder = (m.get("folder") or "").strip()
+        if not exp or not folder:
+            continue
+        started = (m.get("started_at") or "").strip()
+        # reunião recente (dentro do recorte) é preservada; sem data válida = antiga
+        if started:
+            try:
+                if datetime.fromisoformat(started) >= cutoff:
+                    continue
+            except ValueError:
+                pass  # data corrompida → trata como antiga
+        try:
+            md = Path(exp).read_text(encoding="utf-8")
+        except OSError:
+            continue
+        state = load_action_state(Path(folder))
+        for it in parse_action_items(md):
+            if state.get(it["key"], "open") == "open":
+                set_action_state(Path(folder), it["key"], "archived")
+                n += 1
+    return n
 
 
 def set_note_title(md_path: Path, new_title: str) -> None:

--- a/scriba/notes.py
+++ b/scriba/notes.py
@@ -840,6 +840,13 @@ def set_action_done(folder: Path, key: str, done: bool) -> None:
         import logging
 
         logging.getLogger("scriba.notes").warning("falha ao salvar .actions.json em %s: %s", folder, e)
+    # Reflete o clique no snapshot do índice (#76) p/ capa/hub atualizarem sem reindex.
+    # O `.actions.json` acima é a fonte da verdade; o índice é derivado e resiliente
+    # (set_action_state nunca levanta), então isto é best-effort e roda mesmo se o
+    # .actions.json falhou — o próximo reindex reconcilia os dois de qualquer forma.
+    from . import meetings_index  # lazy: evita ciclo (meetings_index importa notes)
+
+    meetings_index.set_action_state(folder, key, "done" if done else "open")
 
 
 def open_action_items(meetings: list[dict]) -> list[dict]:

--- a/scriba/qt/main_window.py
+++ b/scriba/qt/main_window.py
@@ -61,6 +61,27 @@ def _elide(text: str, limit: int) -> str:
     return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
 
 
+def _group_by_note(items: list) -> list:
+    """Agrupa itens de pendência por reunião (`note_path`), preservando a ordem de entrada.
+    Devolve [(item_cabeça, [itens]), …] — o 1º item de cada grupo carrega o contexto
+    (título/data/cliente) do cabeçalho. Evita repetir o subtítulo da reunião (#80)."""
+    groups: list = []
+    index: dict = {}
+    for it in items:
+        key = (it.get("note_path") or "").strip()
+        if key not in index:
+            index[key] = len(groups)
+            groups.append((it, []))
+        groups[index[key]][1].append(it)
+    return groups
+
+
+def _short_date(iso: str) -> str:
+    """'YYYY-MM-DD…' -> 'dd/mm' (data curta do cabeçalho de grupo). '' se vazio/curto."""
+    iso = (iso or "").strip()
+    return f"{iso[8:10]}/{iso[5:7]}" if len(iso) >= 10 else ""
+
+
 def _started_within(m: dict, cutoff_iso: str) -> bool:
     """True se a reunião começou em `cutoff_iso` ou depois (dentro do recorte da capa, #79).
     Data ausente/corrompida → False (vai p/ o backlog: degradação segura, nunca infla ativas)."""
@@ -528,16 +549,18 @@ class MainWindow(QWidget):
             (f"{n} ativa(s) — reuniões dos últimos {days} dias" if days > 0
              else f"{n} pendência(s) — sem recorte") if n else "")
         self._pending_open.setVisible(n > 0)
+        self._pending_active_n = n   # base p/ o badge decrementar ao marcar/dispensar (#80)
         if not pend:
             empty = QLabel("Nada pendente por aqui. ✓")
             empty.setProperty("role", "muted")
             empty.setStyleSheet(f"color:{t.muted}; font-size:{t.font_size_small}pt;")
             self._pending_lay.addWidget(empty)
         else:
-            for it in pend[:_PENDING_N]:
-                self._pending_lay.addWidget(self._pending_item(it))
-            if n > _PENDING_N:
-                more = QLabel(f"+{n - _PENDING_N} outras — abrir Notas")
+            shown = pend[:_PENDING_N]
+            for header_it, items in _group_by_note(shown):
+                self._pending_lay.addWidget(self._pending_group(header_it, items))
+            if n > len(shown):
+                more = QLabel(f"+{n - len(shown)} outras — abrir Notas")
                 more.setProperty("role", "muted")
                 more.setStyleSheet(f"color:{t.muted}; font-size:{t.font_size_small}pt;")
                 self._pending_lay.addWidget(more)
@@ -597,30 +620,98 @@ class MainWindow(QWidget):
             parts.append(f"{n} part.")
         return "  ·  ".join(parts)
 
-    def _pending_item(self, it: dict) -> QWidget:
+    def _pending_group(self, header_it: dict, items: list) -> QWidget:
+        """Um grupo de pendências da MESMA reunião: 1 cabeçalho compacto (título · data ·
+        cliente, clicável) + N itens de 1 linha. Elimina o subtítulo repetido (#80)."""
         t = theme.active()
+        box = QWidget()
+        col = QVBoxLayout(box); col.setContentsMargins(0, 0, 0, 0); col.setSpacing(1)
+        note_path = (header_it.get("note_path") or "").strip()
+        bits = [b for b in (header_it.get("title"), _short_date(header_it.get("started_at")),
+                            header_it.get("client")) if b]
+        hdr = QLabel(_elide("  ·  ".join(bits), 52))
+        hdr.setStyleSheet(f"color:{t.accent_hover}; font-weight:bold; font-size:{t.font_size_small}pt;")
+        hdr.setCursor(Qt.PointingHandCursor)
+        hdr.mousePressEvent = lambda _e, p=note_path: self._open_recent(p)
+        col.addWidget(hdr)
+        for it in items:
+            col.addWidget(self._pending_item(it))
+        return box
+
+    def _label_chip(self, label: str):
+        """Chip colorido da 1ª palavra do rótulo (BLOQUEANTE=rec, ABERTO=warn, resto=neutro).
+        None se não houver rótulo. A IA não usa vocabulário fechado — labels fora dos dois
+        conhecidos caem no neutro sem quebrar."""
+        label = (label or "").strip()
+        if not label:
+            return None
+        t = theme.active()
+        up = label.upper()
+        if "BLOQUEANTE" in up or "BLOCK" in up:
+            bg, fg = t.rec, t.on_accent
+        elif "ABERTO" in up or "OPEN" in up:
+            bg, fg = t.warn, t.on_highlight
+        else:
+            bg, fg = t.field, t.muted
+        chip = QLabel(label.split()[0].upper()); chip.setObjectName("pendChip")
+        chip.setStyleSheet(f"QLabel#pendChip {{ background:{bg}; color:{fg};"
+                           f" border-radius:9px; padding:1px 7px; font-size:{t.font_size_small}pt; }}")
+        return chip
+
+    def _pending_item(self, it: dict) -> QWidget:
+        """Item vivo de 1 linha: checkbox REAL (resolve) + chip de rótulo + texto clicável
+        (navega) + ✕ dispensar. Áreas de clique disjuntas (checkbox marca, texto navega)."""
+        t = theme.active()
+        folder = (it.get("folder") or "").strip()
+        key = it.get("key") or ""
         note_path = (it.get("note_path") or "").strip()
-        row = _ClickRow(lambda p=note_path: self._open_recent(p))
-        rl = QHBoxLayout(row)
-        rl.setContentsMargins(8, 5, 8, 5)
-        rl.setSpacing(9)
-        box = QLabel()   # marcador "a fazer": quadrado VAZIO (um ☑ leria como concluído)
-        box.setFixedSize(13, 13)
-        box.setStyleSheet(f"border:1.5px solid {t.warn}; border-radius:3px; background:transparent;")
-        rl.addWidget(box, 0, Qt.AlignTop)
-        mid = QVBoxLayout()
-        mid.setSpacing(1)
-        txt = QLabel(_elide(it.get("text") or it.get("raw") or "", 44))
+        row = QWidget()
+        rl = QHBoxLayout(row); rl.setContentsMargins(8, 2, 6, 2); rl.setSpacing(7)
+        cb = widgets.AnimatedCheckBox()
+        cb.setFixedWidth(cb._BOX + 6)   # indicador só: clique disjunto do texto
+        rl.addWidget(cb, 0, Qt.AlignVCenter)
+        chip = self._label_chip(it.get("label") or "")
+        if chip is not None:
+            rl.addWidget(chip, 0, Qt.AlignVCenter)
+        txt = QLabel(_elide(it.get("text") or it.get("raw") or "", 40))
         txt.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
-        ctx_bits = [b for b in (it.get("title"), it.get("client")) if b]
-        sub = QLabel(_elide("  ·  ".join(ctx_bits), 44))
-        sub.setStyleSheet(f"color:{t.faint}; font-size:{t.font_size_small}pt;")
-        sub.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
-        mid.addWidget(txt)
-        if ctx_bits:
-            mid.addWidget(sub)
-        rl.addLayout(mid, 1)
+        txt.setCursor(Qt.PointingHandCursor)
+        txt.mousePressEvent = lambda _e, p=note_path: self._open_recent(p)
+        widgets.add_tooltip(txt, it.get("raw") or it.get("text") or "")
+        rl.addWidget(txt, 1)
+        dismiss = widgets.icon_button("dismiss", "Dispensar (falso-positivo)",
+                                      size=13, color=t.faint)
+        rl.addWidget(dismiss, 0, Qt.AlignVCenter)
+
+        def _resolve(on: bool) -> None:
+            from .. import notes
+            if folder and key:
+                notes.set_action_done(folder, key, on)
+            self._style_resolved(txt, on)
+            self._bump_pending_badge(-1 if on else 1)
+
+        def _dismiss() -> None:
+            from .. import notes
+            if folder and key:
+                notes.set_action_state(folder, key, "dismissed")
+            self._style_resolved(txt, True)
+            cb.setEnabled(False); dismiss.setEnabled(False)
+            self._bump_pending_badge(-1)
+
+        cb.toggled.connect(_resolve)
+        dismiss.clicked.connect(_dismiss)
         return row
+
+    def _style_resolved(self, txt_label, on: bool) -> None:
+        t = theme.active()
+        txt_label.setStyleSheet(f"color:{t.muted}; text-decoration:line-through;" if on else "")
+
+    def _bump_pending_badge(self, delta: int) -> None:
+        """Ajusta o badge de ativas sem re-render da home inteira (evita flicker, #80)."""
+        n = max(0, getattr(self, "_pending_active_n", 0) + delta)
+        self._pending_active_n = n
+        self._pending_badge.setText(str(n))
+        self._pending_badge.setVisible(n > 0)
 
     def _open_recent(self, note_path: str) -> None:
         """Clique numa reunião/pendência: abre a nota selecionada (ou só a tela

--- a/scriba/qt/main_window.py
+++ b/scriba/qt/main_window.py
@@ -61,6 +61,13 @@ def _elide(text: str, limit: int) -> str:
     return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
 
 
+def _started_within(m: dict, cutoff_iso: str) -> bool:
+    """True se a reunião começou em `cutoff_iso` ou depois (dentro do recorte da capa, #79).
+    Data ausente/corrompida → False (vai p/ o backlog: degradação segura, nunca infla ativas)."""
+    started = (m.get("started_at") or "").strip()
+    return bool(started) and started >= cutoff_iso
+
+
 def _dot(diameter: int = 10) -> QLabel:
     d = QLabel()
     d.setFixedSize(diameter, diameter)
@@ -450,7 +457,8 @@ class MainWindow(QWidget):
             return
         from .. import meetings_index, notes
 
-        data = {"total": 0, "recent": [], "seconds": 0.0, "clients": 0, "pending": []}
+        data = {"total": 0, "recent": [], "seconds": 0.0, "clients": 0,
+                "pending": [], "pending_stale": 0, "pending_days": 0}
         try:
             data["total"] = meetings_index.count()
         except Exception as e:
@@ -464,8 +472,31 @@ class MainWindow(QWidget):
         data["seconds"] = sum((m.get("duration_s") or 0) for m in done)
         data["clients"] = len({(m.get("client") or "").strip()
                                for m in done if (m.get("client") or "").strip()})
+        # Recorte temporal (#79): só pendências de reuniões dos últimos N dias contam como
+        # ATIVAS na capa; o resto é backlog ("M antigas"). Idade pela DATA DA REUNIÃO
+        # (started_at). days == 0 = sem recorte (conta tudo, como antes).
+        days = 0
         try:
-            data["pending"] = notes.open_action_items(done)
+            days = int(self.app.cfg.ui.pending_window_days)
+        except Exception as e:
+            log.debug("pending_window_days indisponível: %s", e)
+        data["pending_days"] = days
+        try:
+            if days > 0:
+                from datetime import datetime, timedelta
+                cutoff = (datetime.now() - timedelta(days=days)).isoformat()
+                recent = [m for m in done if _started_within(m, cutoff)]
+                data["pending"] = notes.open_action_items(recent)
+                # backlog completo vem do índice (não da lista truncada em 500); guarda
+                # contra índice defasado com max(0, ...).
+                try:
+                    total_open = meetings_index.action_counts().get("open", 0)
+                except Exception as e:
+                    log.debug("action_counts falhou: %s", e)
+                    total_open = len(data["pending"])
+                data["pending_stale"] = max(0, total_open - len(data["pending"]))
+            else:
+                data["pending"] = notes.open_action_items(done)
         except Exception as e:
             log.debug("open_action_items falhou: %s", e)
         self.app.ui(lambda: self._render_home(data))
@@ -485,12 +516,17 @@ class MainWindow(QWidget):
         else:
             for m in recent:
                 self._recent_lay.addWidget(self._recent_item(m))
-        # -- pendências
+        # -- pendências (só as ATIVAS contam no badge; o backlog vira "M antigas", #79)
         _clear_layout(self._pending_lay)
         pend = data["pending"]
         n = len(pend)
+        stale = data.get("pending_stale", 0)
+        days = data.get("pending_days", 0)
         self._pending_badge.setText(str(n))
         self._pending_badge.setVisible(n > 0)
+        self._pending_badge.setToolTip(
+            (f"{n} ativa(s) — reuniões dos últimos {days} dias" if days > 0
+             else f"{n} pendência(s) — sem recorte") if n else "")
         self._pending_open.setVisible(n > 0)
         if not pend:
             empty = QLabel("Nada pendente por aqui. ✓")
@@ -505,6 +541,15 @@ class MainWindow(QWidget):
                 more.setProperty("role", "muted")
                 more.setStyleSheet(f"color:{t.muted}; font-size:{t.font_size_small}pt;")
                 self._pending_lay.addWidget(more)
+        # Badge secundário muted: backlog fora do recorte, linka p/ o hub. Só ocupa
+        # espaço quando há backlog (sem layout shift).
+        if stale > 0:
+            old = QLabel(f'<a href="#">{stale} antiga(s) — ver todas</a>')
+            old.setProperty("role", "muted")
+            old.setStyleSheet(f"color:{t.muted}; font-size:{t.font_size_small}pt;")
+            old.setToolTip("Pendências de reuniões fora do recorte. Abrir o hub para revisar/arquivar.")
+            old.linkActivated.connect(lambda _=None: self._open_pending_hub())
+            self._pending_lay.addWidget(old)
 
     def _recent_item(self, m: dict) -> QWidget:
         t = theme.active()
@@ -584,6 +629,15 @@ class MainWindow(QWidget):
             self.app.show_notes(note_path)
         else:
             self.app.show_notes()
+
+    def _open_pending_hub(self, note_path: str = None) -> None:
+        """Abre o hub de pendências (#82). Tolerante enquanto o hub não existe: cai
+        na tela de Notas. #82 troca o alvo para o hub de primeira classe."""
+        hub = getattr(self.app, "show_action_hub", None)
+        if callable(hub):
+            hub(note_path)
+        else:
+            self.app.show_notes(note_path) if note_path else self.app.show_notes()
 
     def _render_empty_state(self, total: int) -> None:
         t = theme.active()

--- a/scriba/qt/main_window.py
+++ b/scriba/qt/main_window.py
@@ -299,7 +299,7 @@ class MainWindow(QWidget):
         hdr.addStretch(1)
         self._pending_open = QLabel('<a href="#">abrir</a>')
         self._pending_open.setStyleSheet(f"color:{theme.active().muted};")
-        self._pending_open.linkActivated.connect(lambda _=None: self.app.show_notes())
+        self._pending_open.linkActivated.connect(lambda _=None: self._open_pending_hub())
         hdr.addWidget(self._pending_open)
         body.addLayout(hdr)
         body.addSpacing(4)
@@ -560,9 +560,10 @@ class MainWindow(QWidget):
             for header_it, items in _group_by_note(shown):
                 self._pending_lay.addWidget(self._pending_group(header_it, items))
             if n > len(shown):
-                more = QLabel(f"+{n - len(shown)} outras — abrir Notas")
+                more = QLabel(f'<a href="#">+{n - len(shown)} outras — ver todas</a>')
                 more.setProperty("role", "muted")
                 more.setStyleSheet(f"color:{t.muted}; font-size:{t.font_size_small}pt;")
+                more.linkActivated.connect(lambda _=None: self._open_pending_hub())
                 self._pending_lay.addWidget(more)
         # Badge secundário muted: backlog fora do recorte, linka p/ o hub. Só ocupa
         # espaço quando há backlog (sem layout shift).
@@ -632,7 +633,7 @@ class MainWindow(QWidget):
         hdr = QLabel(_elide("  ·  ".join(bits), 52))
         hdr.setStyleSheet(f"color:{t.accent_hover}; font-weight:bold; font-size:{t.font_size_small}pt;")
         hdr.setCursor(Qt.PointingHandCursor)
-        hdr.mousePressEvent = lambda _e, p=note_path: self._open_recent(p)
+        hdr.mousePressEvent = lambda _e, p=note_path: self._open_pending_hub(p)
         col.addWidget(hdr)
         for it in items:
             col.addWidget(self._pending_item(it))
@@ -676,7 +677,7 @@ class MainWindow(QWidget):
         txt = QLabel(_elide(it.get("text") or it.get("raw") or "", 40))
         txt.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
         txt.setCursor(Qt.PointingHandCursor)
-        txt.mousePressEvent = lambda _e, p=note_path: self._open_recent(p)
+        txt.mousePressEvent = lambda _e, p=note_path: self._open_pending_hub(p)
         widgets.add_tooltip(txt, it.get("raw") or it.get("text") or "")
         rl.addWidget(txt, 1)
         dismiss = widgets.icon_button("dismiss", "Dispensar (falso-positivo)",

--- a/scriba/qt/notes_ui.py
+++ b/scriba/qt/notes_ui.py
@@ -25,13 +25,18 @@ from pathlib import Path
 from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtGui import QColor, QTextCharFormat, QTextCursor
 from PySide6.QtWidgets import (
+    QButtonGroup,
+    QComboBox,
     QFrame,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QMenu,
     QMessageBox,
     QProgressBar,
+    QPushButton,
     QScrollArea,
+    QSizePolicy,
     QSplitter,
     QTextBrowser,
     QTextEdit,
@@ -379,13 +384,8 @@ class NotesWindow(QWidget):
                     self._chat.restyle_theme()
             except RuntimeError:
                 self._chat = None
-        aw = getattr(self, "_actions_win", None)
-        if aw is not None:
-            try:
-                if aw.isVisible():
-                    aw._render()
-            except RuntimeError:
-                pass
+        # o hub de pendências é top-level próprio (app.action_hub): _restyle_top_levels
+        # já chama o restyle_theme dele — nada a fazer aqui (#78).
 
     # -- atalhos e menu de contexto (#63) ------------------------------------
 
@@ -1066,10 +1066,14 @@ class NotesWindow(QWidget):
 
     # -- "Minhas pendências" (#22) -------------------------------------------
 
-    def _collect_action_groups(self) -> list:
+    def _collect_action_groups(self) -> list[dict]:
+        """Agrega a seção 'Pendências e Ações' de TODAS as reuniões, uma entrada por
+        reunião: {dt, title, path, folder, client, items}. Ponto ÚNICO de origem dos
+        dados do hub (#78) — a migração p/ o índice (#76) troca só aqui. Ordenado por
+        data desc."""
         from .. import notes
 
-        groups = []
+        groups: list[dict] = []
         try:
             files = list(self._notes_dir().glob("*.md"))
         except OSError:
@@ -1083,18 +1087,36 @@ class NotesWindow(QWidget):
             if not items:
                 continue
             dt, _dur, title = _note_info(f)
-            groups.append((dt, title or f.stem, f, self._recording_folder_for(f), items))
-        groups.sort(key=lambda g: g[0], reverse=True)
+            groups.append({"dt": dt, "title": title or f.stem, "path": f,
+                           "folder": self._recording_folder_for(f),
+                           "client": _client_of(f), "items": items})
+        groups.sort(key=lambda g: g["dt"], reverse=True)
         return groups
 
     def _open_action_items(self) -> None:
-        self._actions_win = _ActionItemsWindow(self._collect_action_groups(), self._reveal_note)
-        self._actions_win.show()
+        # atalho secundário (ícone task-list do rodapé): abre o hub de 1ª classe (#78/#82)
+        self.app.show_action_hub()
 
     def reveal_note(self, note_path) -> None:
         """Navega até a reunião de caminho `note_path` na árvore (público; usado
         pela capa ao clicar numa reunião recente). Aceita str ou Path."""
         self._reveal_note(Path(note_path))
+
+    def reveal_note_at_section(self, note_path, section_title: str = "Pendências e Ações") -> None:
+        """Abre a nota E rola o leitor até a seção `section_title` (default: pendências).
+        Usado pelo hub (#78): clicar num item leva à nota já posicionada. Como o leitor
+        usa setMarkdown (sem âncoras de header), reusa o mecanismo de find por texto
+        (QTextCursor + ensureCursorVisible, padrão do _goto_hit)."""
+        self.show()
+        self.raise_()
+        self._reveal_note(Path(note_path))   # seleciona na árvore → renderiza o markdown
+        if not section_title:
+            return
+        doc = self._view.document()
+        cur = doc.find(section_title)        # 1ª ocorrência do texto do header
+        if not cur.isNull():
+            self._view.setTextCursor(cur)
+            self._view.ensureCursorVisible()
 
     def _reveal_note(self, note_path: Path) -> None:
         if self._select_in_tree(note_path):
@@ -1145,81 +1167,335 @@ class NotesWindow(QWidget):
         self.hide()
 
 
-class _ActionItemsWindow(QWidget):
-    """"Minhas pendências": agrega a seção 'Pendências e Ações' de TODAS as reuniões,
-    com checkbox por item (estado em .actions.json por pasta) e clique no título → nota."""
+def _is_blocking(label: str) -> bool:
+    up = (label or "").upper()
+    return "BLOQUEANTE" in up or "BLOCK" in up
 
-    def __init__(self, groups: list, on_reveal):
+
+def _label_rank(label: str) -> int:
+    """Severidade do rótulo p/ a ordenação 'por rótulo' (bloqueantes no topo)."""
+    up = (label or "").upper()
+    if _is_blocking(label):
+        return 0
+    if "ABERTO" in up or "OPEN" in up:
+        return 1
+    return 2 if (label or "").strip() else 3
+
+
+# filtros de estado do hub (chip -> rótulo). "Ativas" é o default.
+_HUB_FILTERS = (
+    ("active", "Ativas"),
+    ("blocking", "Bloqueantes"),
+    ("done", "Resolvidas"),
+    ("dismissed", "Dispensadas"),
+    ("archived", "Arquivadas"),
+)
+
+
+class _ActionItemsWindow(QWidget):
+    """Hub de pendências (#78): agrega a seção 'Pendências e Ações' de TODAS as reuniões,
+    com filtros (ativas/bloqueantes/resolvidas/dispensadas/arquivadas), por cliente, busca
+    e ordenação; agrupa por reunião (título · data · cliente); rótulos como chips coloridos;
+    clique no item abre a nota já rolada na seção. Estado em .actions.json por pasta
+    (fonte da verdade); navegação delegada à janela de Notas. Instância única do app."""
+
+    def __init__(self, app, collect, on_reveal_section):
         super().__init__()
-        self._groups = groups
-        self._on_reveal = on_reveal
-        self.setWindowTitle("ScribaDev — Minhas pendências")
-        self.setMinimumSize(560, 400)
+        self.app = app
+        self._collect = collect                       # callable -> list[dict] de grupos
+        self._on_reveal_section = on_reveal_section    # callable(path) -> navega até a seção
+        self._groups: list[dict] = []
+        self._filter = "active"
+        self._focus_path = None
+        self._headers: dict[str, QLabel] = {}
+        self.setWindowTitle("ScribaDev — Pendências")
+        self.setMinimumSize(600, 460)
+        widgets.remember_geometry(self, "action_hub", default=(160, 120, 660, 560))
+        self._build()
+
+    # -- construção ----------------------------------------------------------
+    def _build(self) -> None:
         root = QVBoxLayout(self)
         head = QHBoxLayout()
-        title = QLabel("Minhas pendências"); title.setStyleSheet("font-size:15pt; font-weight:bold;")
+        title = QLabel("Pendências"); title.setStyleSheet("font-size:15pt; font-weight:bold;")
         head.addWidget(title)
         self._count = QLabel(""); self._count.setProperty("role", "muted")
-        head.addWidget(self._count); head.addStretch(1)
-        self._show_done = widgets.AnimatedCheckBox("mostrar resolvidas")
-        self._show_done.toggled.connect(self._render)
-        head.addWidget(self._show_done)
+        head.addWidget(self._count)
+        head.addStretch(1)
+        self._archive_btn = QPushButton("Arquivar antigas")
+        self._archive_btn.setCursor(Qt.PointingHandCursor)
+        self._archive_btn.clicked.connect(self._archive_old)
+        head.addWidget(self._archive_btn)
         root.addLayout(head)
+
+        chips = QHBoxLayout(); chips.setSpacing(6)
+        self._chip_group = QButtonGroup(self); self._chip_group.setExclusive(True)
+        self._chips: dict[str, QPushButton] = {}
+        for key, label in _HUB_FILTERS:
+            b = QPushButton(label); b.setCheckable(True); b.setCursor(Qt.PointingHandCursor)
+            b.setObjectName("hubChip")
+            b.clicked.connect(lambda _c=False, k=key: self._set_filter(k))
+            self._chip_group.addButton(b)
+            self._chips[key] = b
+            chips.addWidget(b)
+        self._chips["active"].setChecked(True)
+        chips.addStretch(1)
+        root.addLayout(chips)
+
+        tools = QHBoxLayout(); tools.setSpacing(8)
+        self._client = QComboBox(); widgets.no_wheel_steal(self._client)
+        self._client.currentIndexChanged.connect(lambda _=0: self._render())
+        tools.addWidget(QLabel("Cliente:")); tools.addWidget(self._client)
+        self._sort = QComboBox(); widgets.no_wheel_steal(self._sort)
+        self._sort.addItems(["Data (recente)", "Rótulo"])
+        self._sort.currentIndexChanged.connect(lambda _=0: self._render())
+        tools.addWidget(QLabel("Ordenar:")); tools.addWidget(self._sort)
+        self._search = QLineEdit(); self._search.setClearButtonEnabled(True)
+        self._search.setPlaceholderText("Buscar nos itens…")
+        self._search.textChanged.connect(lambda _=0: self._render())
+        tools.addWidget(self._search, 1)
+        root.addLayout(tools)
+
         self._scroll = QScrollArea(); self._scroll.setWidgetResizable(True)
         self._scroll.setFrameShape(QScrollArea.NoFrame)
         root.addWidget(self._scroll, 1)
+        self._style_controls()
+
+    def _style_controls(self) -> None:
+        # QSS por objectName (#hubChip): scoped, não vaza border p/ filhos (gotcha #70).
+        t = theme.active()
+        for b in self._chips.values():
+            b.setStyleSheet(
+                f"QPushButton#hubChip {{ padding:3px 12px; border-radius:{t.radius}px;"
+                f" border:1px solid {t.border}; background:{t.field}; color:{t.muted}; }}"
+                f"QPushButton#hubChip:checked {{ background:{t.accent}; color:{t.on_accent};"
+                f" border-color:{t.accent}; }}")
+
+    # -- dados / filtros -----------------------------------------------------
+    def refresh(self) -> None:
+        """(Re)coleta os grupos da origem única e re-renderiza (após marcar/dispensar/
+        arquivar, ou ao abrir)."""
+        try:
+            self._groups = self._collect() if self._collect else []
+        except Exception:
+            log.exception("falha ao coletar pendências do hub")
+            self._groups = []
+        self._populate_clients()
         self._render()
 
+    def _populate_clients(self) -> None:
+        cur = self._client.currentText() if self._client.count() else ""
+        clients = sorted({(g["client"] or "").strip() for g in self._groups
+                          if (g["client"] or "").strip()})
+        self._client.blockSignals(True)
+        self._client.clear()
+        self._client.addItem("Todos os clientes")
+        self._client.addItems(clients)
+        i = self._client.findText(cur)
+        self._client.setCurrentIndex(i if i > 0 else 0)
+        self._client.blockSignals(False)
+
+    def _set_filter(self, key: str) -> None:
+        self._filter = key
+        self._render()
+
+    def _passes_filter(self, state: str, label: str) -> bool:
+        f = self._filter
+        if f == "active":
+            return state == "open"
+        if f == "blocking":
+            return state == "open" and _is_blocking(label)
+        return state == f   # done / dismissed / archived
+
+    def focus_meeting(self, note_path) -> None:
+        """Rola até a reunião de `note_path` (abertura via app.show_action_hub(note_path))."""
+        self._focus_path = str(note_path) if note_path else None
+        self._render()
+
+    # -- render --------------------------------------------------------------
     def _render(self) -> None:
         from .. import notes
 
-        body = QWidget()
-        lay = QVBoxLayout(body)
-        open_n = done_n = 0
-        any_visible = False
-        for dt, title, md_path, folder, items in self._groups:
-            state = notes.load_action_state(folder)
-            shown = [it for it in items if self._show_done.isChecked() or not state.get(it["key"])]
-            done_n += sum(1 for it in items if state.get(it["key"]))
-            open_n += sum(1 for it in items if not state.get(it["key"]))
-            if not shown:
+        self._headers = {}
+        client_sel = self._client.currentText() if self._client.currentIndex() > 0 else ""
+        needle = self._search.text().strip().lower()
+        by_label = self._sort.currentIndex() == 1
+        visible: list[tuple[dict, list]] = []
+        for g in self._groups:
+            if client_sel and (g["client"] or "").strip() != client_sel:
                 continue
-            any_visible = True
-            hdr = QLabel(f"{title}  ·  {dt:%d/%m %H:%M}")
-            hdr.setStyleSheet(f"color:{theme.active().accent_hover}; font-weight:bold; font-size:11pt;")
-            hdr.setCursor(Qt.PointingHandCursor)
-            hdr.mousePressEvent = lambda _e, p=md_path: self._on_reveal(p)
-            lay.addWidget(hdr)
-            for it in shown:
-                self._add_item(lay, folder, it, bool(state.get(it["key"])))
-        if not any_visible:
-            lay.addWidget(QLabel("Nenhuma reunião tem pendências." if not self._groups
-                                 else 'Tudo resolvido! Marque "mostrar resolvidas" para revê-las.'))
-        lay.addStretch(1)
-        self._count.setText(f"{open_n} aberta(s) · {done_n} resolvida(s)")
-        self._scroll.setWidget(body)
+            state_map = notes.load_action_state(g["folder"])
+            items = []
+            for it in g["items"]:
+                st = state_map.get(it["key"], "open")
+                if not self._passes_filter(st, it.get("label", "")):
+                    continue
+                if needle and needle not in (
+                        f"{it.get('text', '')} {it.get('raw', '')} {it.get('label', '')}".lower()):
+                    continue
+                items.append((it, st))
+            if not items:
+                continue
+            if by_label:
+                items.sort(key=lambda pair: _label_rank(pair[0].get("label", "")))
+            visible.append((g, items))
+        if by_label:
+            visible.sort(key=lambda gi: min(_label_rank(it.get("label", "")) for it, _ in gi[1]))
 
-    def _add_item(self, lay, folder, item, done) -> None:
+        body = QWidget(); lay = QVBoxLayout(body)
+        shown_total = 0
+        for g, items in visible:
+            self._add_group_header(lay, g)
+            for it, st in items:
+                self._add_item(lay, g, it, st)
+                shown_total += 1
+        if shown_total == 0:
+            empty = QLabel(self._empty_text()); empty.setProperty("role", "muted")
+            lay.addWidget(empty)
+        lay.addStretch(1)
+        self._count.setText(f"{shown_total} item(ns)")
+        self._scroll.setWidget(body)
+        if self._focus_path is not None:
+            hdr = self._headers.get(self._focus_path)
+            if hdr is not None:
+                self._scroll.ensureWidgetVisible(hdr)
+            self._focus_path = None
+
+    def _empty_text(self) -> str:
+        return {
+            "active": "Nenhuma pendência ativa. ✓",
+            "blocking": "Nenhuma pendência bloqueante.",
+            "done": "Nada resolvido ainda.",
+            "dismissed": "Nada dispensado.",
+            "archived": "Nada arquivado.",
+        }.get(self._filter, "Nada por aqui.")
+
+    def _add_group_header(self, lay, g: dict) -> None:
+        t = theme.active()
+        bits = [g["title"], f"{g['dt']:%d/%m %H:%M}"]
+        if (g["client"] or "").strip():
+            bits.append(g["client"].strip())
+        hdr = QLabel("  ·  ".join(bits))
+        hdr.setStyleSheet(f"color:{t.accent_hover}; font-weight:bold; font-size:{t.font_size_small + 1}pt;")
+        hdr.setCursor(Qt.PointingHandCursor)
+        hdr.mousePressEvent = lambda _e, p=g["path"]: self._on_reveal_section(p)
+        lay.addWidget(hdr)
+        self._headers[str(g["path"])] = hdr
+
+    def _label_chip(self, label: str) -> QLabel:
+        t = theme.active()
+        up = (label or "").upper()
+        if _is_blocking(label):
+            bg, fg = t.rec, t.on_accent
+        elif "ABERTO" in up or "OPEN" in up:
+            bg, fg = t.warn, t.on_highlight
+        else:
+            bg, fg = t.field, t.muted
+        word = label.split()[0].upper() if label.split() else ""
+        chip = QLabel(word); chip.setObjectName("hubLabelChip")
+        chip.setStyleSheet(f"QLabel#hubLabelChip {{ background:{bg}; color:{fg};"
+                           f" border-radius:9px; padding:1px 8px; font-size:{t.font_size_small}pt; }}")
+        return chip
+
+    def _add_item(self, lay, g: dict, item: dict, state: str) -> None:
         from .. import notes
 
-        text = (f"[{item['label']}] " if item.get("label") else "") + (item.get("text") or item.get("raw") or "")
-        cb = widgets.AnimatedCheckBox(text)
-        cb.setChecked(done)
-        if done:
-            cb.setStyleSheet(f"color:{theme.active().muted}; text-decoration:line-through;")
+        t = theme.active()
+        row = QWidget()
+        rl = QHBoxLayout(row); rl.setContentsMargins(14, 1, 4, 1); rl.setSpacing(8)
+        cb = widgets.AnimatedCheckBox()
+        cb.setFixedWidth(cb._BOX + 8)   # indicador só: área de clique disjunta do texto
+        cb.setChecked(state == "done")
 
-        def toggle(on, f=folder, k=item["key"]) -> None:
-            notes.set_action_done(f, k, on)
+        def toggle(on, folder=g["folder"], k=item["key"]) -> None:
+            notes.set_action_done(folder, k, on)
             self._render()
 
         cb.toggled.connect(toggle)
-        lay.addWidget(cb)
+        rl.addWidget(cb, 0, Qt.AlignTop)
+        if item.get("label"):
+            rl.addWidget(self._label_chip(item["label"]), 0, Qt.AlignTop)
+        txt = QLabel(item.get("text") or item.get("raw") or "")
+        txt.setWordWrap(True)
+        txt.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
+        if state == "done":
+            txt.setStyleSheet(f"color:{t.muted}; text-decoration:line-through;")
+        elif state in ("dismissed", "archived"):
+            txt.setStyleSheet(f"color:{t.muted};")
+        txt.setCursor(Qt.PointingHandCursor)
+        txt.mousePressEvent = lambda _e, p=g["path"]: self._on_reveal_section(p)
+        widgets.add_tooltip(txt, item.get("raw") or item.get("text") or "")
+        rl.addWidget(txt, 1)
+        if state in ("dismissed", "archived"):
+            rl.addWidget(widgets.icon_button(
+                "refresh", "Reabrir (voltar para ativa)",
+                lambda folder=g["folder"], k=item["key"]: self._set_state(folder, k, "open"),
+                size=15), 0, Qt.AlignTop)
+        else:
+            rl.addWidget(widgets.icon_button(
+                "dismiss", "Dispensar (falso-positivo)",
+                lambda folder=g["folder"], k=item["key"]: self._set_state(folder, k, "dismissed"),
+                size=15), 0, Qt.AlignTop)
+        lay.addWidget(row)
+
+    def _set_state(self, folder, key: str, state: str) -> None:
+        from .. import notes
+
+        notes.set_action_state(folder, key, state)
+        self._render()
+
+    def _archive_old(self) -> None:
+        from datetime import datetime, timedelta
+
+        from .. import notes
+
+        try:
+            days = int(self.app.cfg.ui.pending_window_days)
+        except Exception:
+            days = 30
+        if days <= 0:
+            QMessageBox.information(self, "Arquivar antigas",
+                                    "O recorte está desligado (0 dias). Ajuste em Configurações.")
+            return
+        cutoff = datetime.now() - timedelta(days=days)
+        pending = 0
+        for g in self._groups:
+            if g["dt"] >= cutoff:
+                continue
+            st = notes.load_action_state(g["folder"])
+            pending += sum(1 for it in g["items"] if st.get(it["key"], "open") == "open")
+        if pending == 0:
+            QMessageBox.information(self, "Arquivar antigas",
+                                    f"Nenhuma pendência ativa em reuniões com mais de {days} dias.")
+            return
+        resp = QMessageBox.question(
+            self, "Arquivar antigas",
+            f"Arquivar {pending} pendência(s) de reuniões com mais de {days} dias?\n"
+            "Ficam recuperáveis no filtro Arquivadas.")
+        if resp != QMessageBox.Yes:
+            return
+        meetings = [{"export_path": str(g["path"]), "folder": str(g["folder"]),
+                     "started_at": g["dt"].isoformat()} for g in self._groups]
+        n = notes.archive_old_action_items(meetings, older_than_days=days)
+        self.refresh()
+        widgets.flash_button(self._archive_btn, f"{n} arquivada(s)", "Arquivar antigas")
+
+    # -- janela --------------------------------------------------------------
+    def restyle_theme(self) -> None:
+        """Troca de tema a quente (#70/#78): re-aplica os estilos inline (chips, cabeçalhos,
+        rótulos, strikethrough) re-renderizando. Chamado por theme._restyle_top_levels."""
+        self._style_controls()
+        self._render()
 
     def show(self) -> None:  # noqa: A003
         super().show()
         self.raise_()
         self.activateWindow()
         widgets.enable_dark_titlebar(self)
+
+    def closeEvent(self, event) -> None:
+        event.ignore()
+        self.hide()
 
 
 def _clip(text: str) -> None:

--- a/scriba/qt/settings_ui.py
+++ b/scriba/qt/settings_ui.py
@@ -404,6 +404,8 @@ class SettingsWindow(QWidget):
                    tooltip="Atalho global de gravar/parar. Vazio desativa.")
         self._text(ui, "Atalho nova call (dividir)", "ui", "hotkey_split", placeholder="ex.: ctrl+alt+n",
                    tooltip="Divide a call atual em duas. Vazio desativa.")
+        self._int(ui, "Pendências ativas: últimos (dias)", "ui", "pending_window_days", 0, 3650,
+                  hint="0 = sem recorte (conta todas); idade conta pela data da reunião")
 
     def _build_transcription_tab(self) -> None:
         f = self._tab("Transcrição")

--- a/scriba/qt/tray.py
+++ b/scriba/qt/tray.py
@@ -66,6 +66,7 @@ class Tray:
         m.addSeparator()
         m.addAction("Abrir ScribaDev", lambda: self.app.show_main())  # = duplo clique
         m.addAction("Notas", lambda: self.app.show_notes())
+        m.addAction("Pendências", lambda: self.app.show_action_hub())
         m.addAction("Log", lambda: self.app.show_log())
         m.addAction("Configurações", lambda: self.app.show_settings())
         self._theme_menu = self._build_theme_menu()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,6 +84,32 @@ class DiarizationConfigTests(unittest.TestCase):
         self.assertEqual(got.chunk_minutes, 5)
 
 
+class UiConfigTests(unittest.TestCase):
+    """Campos de [ui], incluindo o recorte de pendências da capa (#79)."""
+
+    def setUp(self):
+        d = Path(tempfile.mkdtemp(prefix="scriba_ui_"))
+        util.APP_DIR = d
+        util.LOGS_DIR = d / "logs"
+        util.CONFIG_PATH = d / "config.toml"
+
+    def test_default_pending_window_days(self):
+        self.assertEqual(config.load().ui.pending_window_days, 30)
+
+    def test_round_trip_pending_window_days(self):
+        import dataclasses
+
+        cfg = config.load()
+        config.save(dataclasses.replace(cfg, ui=dataclasses.replace(
+            cfg.ui, pending_window_days=7)))
+        self.assertEqual(config.load().ui.pending_window_days, 7)
+        # 0 = sem recorte (escape hatch) também persiste
+        cfg = config.load()
+        config.save(dataclasses.replace(cfg, ui=dataclasses.replace(
+            cfg.ui, pending_window_days=0)))
+        self.assertEqual(config.load().ui.pending_window_days, 0)
+
+
 class WhisperConfigTests(unittest.TestCase):
     """Novos campos de [whisper] (#6): beam_size, cpu_threads, vad, batch_size (#7: default 4)."""
 

--- a/tests/test_meetings_index.py
+++ b/tests/test_meetings_index.py
@@ -39,7 +39,7 @@ class MeetingsIndexTests(unittest.TestCase):
     def _make_meeting(self, name, *, started_at, title="Reunião X", client="",
                       status="done", presentes=None, mencionados=None,
                       body="assunto generico", duration_s=600, meeting_title="",
-                      transcript_token="ZZTRANSCONLYZZ"):
+                      transcript_token="ZZTRANSCONLYZZ", pendencias=None):
         folder = self.rec / name
         folder.mkdir(parents=True, exist_ok=True)
         meta = {
@@ -54,6 +54,9 @@ class MeetingsIndexTests(unittest.TestCase):
         if mencionados:
             lines += ["", "**Mencionados (não necessariamente presentes):**"]
             lines += [f"- **{n}** — citado" for n in mencionados]
+        # pendencias = lista de bullets crus da seção "## Pendências e Ações" (#76)
+        if pendencias:
+            lines += ["", "## Pendências e Ações"] + [f"- {p}" for p in pendencias]
         # token SÓ na transcrição: prova que a transcrição completa NÃO é indexada
         lines += ["", mi._TRANSCRIPT_MARKER, "", f"**[00:00:00] Eu:** {transcript_token}", ""]
         (folder / "notas.md").write_text("\n".join(lines), encoding="utf-8")
@@ -290,6 +293,150 @@ class MeetingsIndexTests(unittest.TestCase):
         mi.mark_deleted(f)  # não cria tombstone solto, não quebra
         self.assertEqual(mi.count(), 0)
         self.assertFalse((f / mi._DELETED_MARKER).exists())
+
+    # -- pendências (action items) no índice (#76) ---------------------------
+    def _action_rows(self, folder):
+        """Linhas de action_items da pasta, ordenadas por position (helper de teste)."""
+        import sqlite3
+        with sqlite3.connect(str(mi.DB_PATH)) as c:
+            c.row_factory = sqlite3.Row
+            return [dict(r) for r in c.execute(
+                "SELECT a.* FROM action_items a JOIN meetings m ON m.id = a.meeting_id "
+                "WHERE m.folder = ? ORDER BY a.position", (str(folder),)).fetchall()]
+
+    def test_schema_tem_tabela_action_items(self):
+        mi.count()  # cria o schema
+        import sqlite3
+        with sqlite3.connect(str(mi.DB_PATH)) as c:
+            row = c.execute("SELECT name FROM sqlite_master WHERE type='table' "
+                            "AND name='action_items'").fetchone()
+        self.assertIsNotNone(row)
+
+    def test_indexa_popula_action_items(self):
+        f = self._make_meeting("a", started_at="2026-06-10T09:00:00", pendencias=[
+            "**[BLOQUEANTE]** Aplicar nota 123 [00:01:02]",
+            "**[ABERTO]** Enviar estimativa",
+            "Nada identificado.",  # deve ser ignorado pelo parser
+        ])
+        mi.index_meeting(f)
+        rows = self._action_rows(f)
+        self.assertEqual(len(rows), 2)  # o "Nada identificado." não vira linha
+        self.assertEqual(rows[0]["label"], "BLOQUEANTE")
+        self.assertTrue(rows[0]["text"].startswith("Aplicar nota 123"))
+        self.assertEqual([r["position"] for r in rows], [0, 1])
+        self.assertEqual([r["state"] for r in rows], ["open", "open"])
+        # key bate com o parser (fonte da verdade)
+        parsed = notes.parse_action_items((f / "notas.md").read_text(encoding="utf-8"))
+        self.assertEqual([r["key"] for r in rows], [p["key"] for p in parsed])
+
+    def test_state_done_vem_do_actions_json(self):
+        f = self._make_meeting("a", started_at="2026-06-10T09:00:00", pendencias=[
+            "**[BLOQUEANTE]** Aplicar nota 123", "**[ABERTO]** Enviar estimativa"])
+        parsed = notes.parse_action_items((f / "notas.md").read_text(encoding="utf-8"))
+        notes.set_action_done(f, parsed[0]["key"], True)  # marca o 1º ANTES de indexar
+        mi.index_meeting(f)
+        rows = self._action_rows(f)
+        by_key = {r["key"]: r["state"] for r in rows}
+        self.assertEqual(by_key[parsed[0]["key"]], "done")
+        self.assertEqual(by_key[parsed[1]["key"]], "open")
+
+    def test_cascata_exclui_action_items(self):
+        f = self._make_meeting("a", started_at="2026-06-10T09:00:00",
+                               pendencias=["**[ABERTO]** Fazer X"])
+        mi.index_meeting(f)
+        self.assertEqual(len(self._action_rows(f)), 1)
+        mi.remove_meeting(f)
+        self.assertEqual(self._action_rows(f), [])  # cascata: nenhuma órfã
+        import sqlite3
+        with sqlite3.connect(str(mi.DB_PATH)) as c:
+            self.assertEqual(c.execute("SELECT COUNT(*) FROM action_items").fetchone()[0], 0)
+
+    def test_tombstone_nao_gera_action_items(self):
+        f = self._make_meeting("a", started_at="2026-06-10T09:00:00",
+                               pendencias=["**[ABERTO]** Fazer X"])
+        (f / mi._DELETED_MARKER).write_text("", encoding="utf-8")
+        mi.reindex(self.rec)
+        self.assertEqual(self._action_rows(f), [])
+
+    def test_set_action_done_reflete_no_indice_sem_reindex(self):
+        f = self._make_meeting("a", started_at="2026-06-10T09:00:00", pendencias=[
+            "**[BLOQUEANTE]** Aplicar nota 123", "**[ABERTO]** Enviar estimativa"])
+        mi.index_meeting(f)
+        key = notes.parse_action_items((f / "notas.md").read_text(encoding="utf-8"))[0]["key"]
+        notes.set_action_done(f, key, True)  # hook atualiza o índice na hora
+        by_key = {r["key"]: r["state"] for r in self._action_rows(f)}
+        self.assertEqual(by_key[key], "done")
+        notes.set_action_done(f, key, False)  # desmarcar volta p/ open
+        by_key = {r["key"]: r["state"] for r in self._action_rows(f)}
+        self.assertEqual(by_key[key], "open")
+
+    def test_set_action_state_resiliente_a_indice_indisponivel(self):
+        # índice quebrado NÃO pode derrubar o set_action_done nem perder o .actions.json
+        f = self._make_meeting("a", started_at="2026-06-10T09:00:00",
+                               pendencias=["**[ABERTO]** Fazer X"])
+        mi.index_meeting(f)
+        key = notes.parse_action_items((f / "notas.md").read_text(encoding="utf-8"))[0]["key"]
+        orig = mi._connect
+        mi._connect = lambda: (_ for _ in ()).throw(RuntimeError("índice fora"))
+        try:
+            self.assertFalse(mi.set_action_state(f, key, "done"))  # não levanta, devolve False
+            notes.set_action_done(f, key, True)  # também não levanta
+        finally:
+            mi._connect = orig
+        self.assertTrue(notes.load_action_state(f).get(key))  # .actions.json íntegro
+
+    def test_set_action_state_folder_nao_indexada(self):
+        # pasta sem linha no índice: UPDATE não casa nada → False, sem erro
+        self.assertFalse(mi.set_action_state(self.rec / "inexistente", "abc123", "done"))
+
+    def test_action_counts_por_estado_e_recorte(self):
+        a = self._make_meeting("a", started_at="2026-06-10T09:00:00", pendencias=[
+            "**[BLOQUEANTE]** X1", "**[ABERTO]** X2"])
+        b = self._make_meeting("b", started_at="2026-06-20T09:00:00",
+                               pendencias=["**[ABERTO]** Y1"])
+        mi.index_meeting(a)
+        mi.index_meeting(b)
+        # marca X1 como done
+        k = notes.parse_action_items((a / "notas.md").read_text(encoding="utf-8"))[0]["key"]
+        notes.set_action_done(a, k, True)
+        self.assertEqual(mi.action_counts(), {"open": 2, "done": 1})
+        # recorte temporal: só a reunião 'b' (>= 15/06) → 1 open, 0 done
+        self.assertEqual(mi.action_counts(since="2026-06-15"), {"open": 1})
+
+    def test_list_action_items_filtros_e_contexto(self):
+        a = self._make_meeting("a", started_at="2026-06-10T09:00:00", client="ACME",
+                               title="Kickoff", pendencias=[
+                                   "**[BLOQUEANTE]** X1", "**[ABERTO]** X2"])
+        b = self._make_meeting("b", started_at="2026-06-20T09:00:00", client="Globex",
+                               pendencias=["**[ABERTO]** Y1"])
+        mi.index_meeting(a)
+        mi.index_meeting(b)
+        # todos: 3 itens, mais recente (b) primeiro; itens de 'a' na ordem da nota
+        alli = mi.list_action_items()
+        self.assertEqual([i["text"] for i in alli], ["Y1", "X1", "X2"])
+        # contexto p/ abrir a nota
+        self.assertEqual(alli[0]["client"], "Globex")
+        self.assertEqual(alli[0]["folder"], str(b))
+        self.assertEqual(alli[1]["title"], "Kickoff")
+        # filtro por cliente (parcial, case-insensitive)
+        self.assertEqual([i["text"] for i in mi.list_action_items(client="acme")], ["X1", "X2"])
+        # filtro por estado
+        k = notes.parse_action_items((a / "notas.md").read_text(encoding="utf-8"))[0]["key"]
+        notes.set_action_done(a, k, True)
+        self.assertEqual([i["text"] for i in mi.list_action_items(state="done")], ["X1"])
+        self.assertEqual({i["text"] for i in mi.list_action_items(state="open")}, {"X2", "Y1"})
+        # recorte temporal
+        self.assertEqual([i["text"] for i in mi.list_action_items(since="2026-06-15")], ["Y1"])
+
+    def test_list_action_items_paridade_com_parse(self):
+        # paridade com o cálculo antigo (open_action_items): mesmos itens abertos
+        a = self._make_meeting("a", started_at="2026-06-10T09:00:00", pendencias=[
+            "**[BLOQUEANTE]** Aplicar nota", "**[ABERTO]** Enviar estimativa"])
+        mi.index_meeting(a)
+        idx_open = {i["key"] for i in mi.list_action_items(state="open")}
+        parse_open = {i["key"] for i in notes.parse_action_items(
+            (a / "notas.md").read_text(encoding="utf-8"))}  # nenhum resolvido ainda
+        self.assertEqual(idx_open, parse_open)
 
 
 if __name__ == "__main__":

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -364,12 +364,45 @@ class ActionStateTests(unittest.TestCase):
 
     def test_marca_e_desmarca(self):
         notes.set_action_done(self.tmp, "abc", True)
-        self.assertEqual(notes.load_action_state(self.tmp), {"abc": True})
+        self.assertEqual(notes.load_action_state(self.tmp), {"abc": "done"})  # estado nomeado (#77)
         notes.set_action_done(self.tmp, "abc", False)
         self.assertEqual(notes.load_action_state(self.tmp), {})
 
     def test_load_ausente_vira_vazio(self):
         self.assertEqual(notes.load_action_state(self.tmp / "nao_existe"), {})
+
+    # -- estados nomeados + retrocompat (#77) --------------------------------
+    def test_retrocompat_le_bool_legado_como_done(self):
+        # arquivo antigo {key: true} deve ser lido como 'done' (sem migração destrutiva)
+        (self.tmp / ".actions.json").write_text(
+            json.dumps({"k1": True, "k2": False}), encoding="utf-8")
+        self.assertEqual(notes.load_action_state(self.tmp), {"k1": "done"})  # false = aberto (omitido)
+
+    def test_le_estados_nomeados(self):
+        (self.tmp / ".actions.json").write_text(
+            json.dumps({"a": "done", "b": "dismissed", "c": "archived", "d": "open", "e": "bogus"}),
+            encoding="utf-8")
+        # 'open' e valor desconhecido saem do dict (ausência = aberto)
+        self.assertEqual(notes.load_action_state(self.tmp),
+                         {"a": "done", "b": "dismissed", "c": "archived"})
+
+    def test_set_action_state_open_remove_a_chave(self):
+        notes.set_action_state(self.tmp, "k", "dismissed")
+        self.assertEqual(notes.load_action_state(self.tmp), {"k": "dismissed"})
+        notes.set_action_state(self.tmp, "k", "open")  # volta p/ aberto = remove
+        self.assertEqual(notes.load_action_state(self.tmp), {})
+        # e o arquivo não acumula "open"
+        raw = json.loads((self.tmp / ".actions.json").read_text(encoding="utf-8"))
+        self.assertNotIn("k", raw)
+
+    def test_set_action_state_dismissed_e_archived(self):
+        notes.set_action_state(self.tmp, "k1", "dismissed")
+        notes.set_action_state(self.tmp, "k2", "archived")
+        self.assertEqual(notes.load_action_state(self.tmp), {"k1": "dismissed", "k2": "archived"})
+
+    def test_set_action_state_valor_invalido_vira_open(self):
+        notes.set_action_state(self.tmp, "k", "xpto")  # estado inválido → open (remove)
+        self.assertEqual(notes.load_action_state(self.tmp), {})
 
 
 class OpenActionItemsTests(unittest.TestCase):
@@ -408,7 +441,18 @@ class OpenActionItemsTests(unittest.TestCase):
         self.assertEqual(items[0]["title"], "reuniao_a")
         self.assertEqual(items[0]["client"], "ACME")
         self.assertEqual(items[0]["note_path"], m["export_path"])
+        self.assertEqual(items[0]["folder"], m["folder"])  # #80: folder p/ marcar/dispensar
         self.assertTrue(items[0]["text"].startswith("Aplicar"))
+
+    def test_dismissed_e_archived_saem_do_contador(self):
+        m = self._meeting("reuniao_x")
+        keys = [i["key"] for i in notes.open_action_items([m])]
+        notes.set_action_state(Path(m["folder"]), keys[0], "dismissed")
+        # só o segundo (open) sobra; dismissed não conta como ativa
+        rest = notes.open_action_items([m])
+        self.assertEqual([i["key"] for i in rest], [keys[1]])
+        notes.set_action_state(Path(m["folder"]), keys[1], "archived")
+        self.assertEqual(notes.open_action_items([m]), [])  # archived também sai
 
     def test_descarta_resolvidos(self):
         m = self._meeting("reuniao_b")
@@ -434,6 +478,82 @@ class OpenActionItemsTests(unittest.TestCase):
     def test_reuniao_sem_pendencias(self):
         m = self._meeting("vazia", md="# X\n\n## Resumo\ntexto\n")
         self.assertEqual(notes.open_action_items([m]), [])
+
+
+class ArchiveOldActionItemsTests(unittest.TestCase):
+    """notes.archive_old_action_items: arquiva em massa o backlog antigo (#77)."""
+
+    _MD = (
+        "# Reunião\n\n## Pendências e Ações\n"
+        "- **[BLOQUEANTE]** Aplicar nota 123 no QAS\n"
+        "- **[ABERTO]** Enviar estimativa\n"
+    )
+
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._td.name)
+        # set_action_state reflete no índice: isolar APP_DIR/DB_PATH p/ não tocar o real
+        self._app0, self._logs0, self._db0 = util.APP_DIR, util.LOGS_DIR, mi.DB_PATH
+        util.APP_DIR = self.tmp / "app"
+        util.LOGS_DIR = util.APP_DIR / "logs"
+        mi.DB_PATH = util.APP_DIR / "index.db"
+        from datetime import datetime
+        self.now = datetime(2026, 7, 5, 12, 0, 0)
+
+    def tearDown(self):
+        util.APP_DIR, util.LOGS_DIR, mi.DB_PATH = self._app0, self._logs0, self._db0
+        self._td.cleanup()
+
+    def _meeting(self, name, *, days_ago, md=None):
+        from datetime import timedelta
+        folder = self.tmp / name
+        folder.mkdir()
+        note = folder / f"{name}.md"
+        note.write_text(self._MD if md is None else md, encoding="utf-8")
+        started = (self.now - timedelta(days=days_ago)).isoformat()
+        return {"export_path": str(note), "folder": str(folder), "started_at": started}
+
+    def test_arquiva_so_reunioes_antigas(self):
+        recente = self._meeting("recente", days_ago=5)
+        antiga = self._meeting("antiga", days_ago=90)
+        n = notes.archive_old_action_items([recente, antiga], older_than_days=30,
+                                           reference_date=self.now)
+        self.assertEqual(n, 2)  # os 2 itens abertos da reunião antiga
+        # a recente fica intacta (nada arquivado)
+        self.assertEqual(notes.load_action_state(Path(recente["folder"])), {})
+        # a antiga: ambos os itens agora archived
+        st = notes.load_action_state(Path(antiga["folder"]))
+        self.assertEqual(set(st.values()), {"archived"})
+        self.assertEqual(len(st), 2)
+
+    def test_nao_toca_itens_ja_resolvidos_ou_dispensados(self):
+        antiga = self._meeting("antiga", days_ago=90)
+        keys = [i["key"] for i in notes.open_action_items([antiga])]
+        notes.set_action_state(Path(antiga["folder"]), keys[0], "done")
+        n = notes.archive_old_action_items([antiga], older_than_days=30, reference_date=self.now)
+        self.assertEqual(n, 1)  # só o item que estava open
+        st = notes.load_action_state(Path(antiga["folder"]))
+        self.assertEqual(st[keys[0]], "done")       # done preservado
+        self.assertEqual(st[keys[1]], "archived")   # o open virou archived
+
+    def test_reuniao_sem_data_conta_como_antiga(self):
+        m = self._meeting("sem_data", days_ago=0)
+        m["started_at"] = ""  # dado ausente → tratado como antigo (degradação segura)
+        n = notes.archive_old_action_items([m], older_than_days=30, reference_date=self.now)
+        self.assertEqual(n, 2)
+
+    def test_older_than_zero_nao_arquiva(self):
+        antiga = self._meeting("antiga", days_ago=90)
+        self.assertEqual(
+            notes.archive_old_action_items([antiga], older_than_days=0, reference_date=self.now), 0)
+        self.assertEqual(notes.load_action_state(Path(antiga["folder"])), {})
+
+    def test_nao_modifica_o_md(self):
+        antiga = self._meeting("antiga", days_ago=90)
+        before = (Path(antiga["folder"]) / "antiga.md").read_text(encoding="utf-8")
+        notes.archive_old_action_items([antiga], older_than_days=30, reference_date=self.now)
+        after = (Path(antiga["folder"]) / "antiga.md").read_text(encoding="utf-8")
+        self.assertEqual(before, after)  # estado vive só no sidecar; .md intacto
 
 
 if __name__ == "__main__":

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from scriba import meetings_index as mi  # noqa: E402
 from scriba import notes, speakers, util  # noqa: E402
 from scriba.notes import split_header  # noqa: E402
 
@@ -351,8 +352,14 @@ class ActionStateTests(unittest.TestCase):
     def setUp(self):
         self._td = tempfile.TemporaryDirectory()
         self.tmp = Path(self._td.name)
+        # set_action_done reflete no índice (#76): isolar APP_DIR/DB_PATH p/ não tocar o real
+        self._app0, self._logs0, self._db0 = util.APP_DIR, util.LOGS_DIR, mi.DB_PATH
+        util.APP_DIR = self.tmp / "app"
+        util.LOGS_DIR = util.APP_DIR / "logs"
+        mi.DB_PATH = util.APP_DIR / "index.db"
 
     def tearDown(self):
+        util.APP_DIR, util.LOGS_DIR, mi.DB_PATH = self._app0, self._logs0, self._db0
         self._td.cleanup()
 
     def test_marca_e_desmarca(self):
@@ -377,8 +384,14 @@ class OpenActionItemsTests(unittest.TestCase):
     def setUp(self):
         self._td = tempfile.TemporaryDirectory()
         self.tmp = Path(self._td.name)
+        # set_action_done reflete no índice (#76): isolar APP_DIR/DB_PATH p/ não tocar o real
+        self._app0, self._logs0, self._db0 = util.APP_DIR, util.LOGS_DIR, mi.DB_PATH
+        util.APP_DIR = self.tmp / "app"
+        util.LOGS_DIR = util.APP_DIR / "logs"
+        mi.DB_PATH = util.APP_DIR / "index.db"
 
     def tearDown(self):
+        util.APP_DIR, util.LOGS_DIR, mi.DB_PATH = self._app0, self._logs0, self._db0
         self._td.cleanup()
 
     def _meeting(self, name, md=None):

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -88,10 +88,14 @@ class RelabelSpeakersTests(unittest.TestCase):
 
     def setUp(self):
         self.d = Path(tempfile.mkdtemp(prefix="scriba_relabel_"))
-        # store de voz ISOLADO — nunca tocar no speakers.json real do usuário
+        # store de voz E índice ISOLADOS — relabel_speakers re-indexa (hook index_meeting),
+        # então SEM isolar mi.DB_PATH o teste gravaria no index.db REAL do usuário.
+        self._app0, self._logs0, self._store0, self._db0 = (
+            util.APP_DIR, util.LOGS_DIR, speakers.STORE_PATH, mi.DB_PATH)
         util.APP_DIR = self.d / "app"
         util.LOGS_DIR = util.APP_DIR / "logs"
         speakers.STORE_PATH = util.APP_DIR / "speakers.json"
+        mi.DB_PATH = util.APP_DIR / "index.db"
         self.rec = self.d / "rec"
         self.rec.mkdir(parents=True)
         self.export = self.d / "2026-06-10_20-00_reuniao.md"
@@ -109,6 +113,10 @@ class RelabelSpeakersTests(unittest.TestCase):
         self.export.write_text(nota, encoding="utf-8")
         (self.rec / "meta.json").write_text(
             json.dumps({"export_path": str(self.export)}), encoding="utf-8")
+
+    def tearDown(self):
+        util.APP_DIR, util.LOGS_DIR, speakers.STORE_PATH, mi.DB_PATH = (
+            self._app0, self._logs0, self._store0, self._db0)
 
     def test_aprende_e_corrige_nota_e_transcricao(self):
         ok = notes.relabel_speakers(self.rec, {"Participante 2": "Marcelo"})

--- a/tests/test_qt_main_window.py
+++ b/tests/test_qt_main_window.py
@@ -20,6 +20,7 @@ class _FakeApp:
         self.update_news = None
         self.cfg = None            # sem app real: _collect_home não toca o índice
         self.notes_opened = "unset"
+        self.hub_opened = "unset"
 
     def is_recording(self): return self._rec
     def current_call_app(self): return "Teams"
@@ -27,6 +28,7 @@ class _FakeApp:
     def call_duration(self): return 30.0
     def show_settings(self): pass
     def show_notes(self, note_path=None): self.notes_opened = note_path
+    def show_action_hub(self, note_path=None): self.hub_opened = note_path
     def show_log(self): pass
     def start_recording(self, *a): pass
     def stop_recording(self, **k): pass
@@ -210,6 +212,21 @@ class MainWindowTests(unittest.TestCase):
         win._bump_pending_badge(-5)
         self.assertEqual(win._pending_badge.text(), "0")
         self.assertFalse(win._pending_badge.isVisible())
+
+    # -- roteamento capa → hub (#82) --------------------------------------------
+    def test_open_pending_hub_roteia_para_o_hub(self):
+        win = self._win()
+        win._open_pending_hub("/notas/a.md")
+        self.assertEqual(win.app.hub_opened, "/notas/a.md")   # abriu o hub na reunião
+        win._open_pending_hub()
+        self.assertIsNone(win.app.hub_opened)                 # abriu o hub sem reunião
+
+    def test_open_pending_hub_fallback_sem_hub(self):
+        # app sem show_action_hub (build antigo): cai na tela de Notas, não quebra
+        win = self._win()
+        win.app.show_action_hub = None   # instância shadowa o método → getattr não-callable
+        win._open_pending_hub("/notas/b.md")
+        self.assertEqual(win.app.notes_opened, "/notas/b.md")
 
     def test_restyle_theme_nao_retem_acento_do_tema_anterior(self):
         """Regressão do bug #70 (bordas laranjas): trocar de tema a quente deve

--- a/tests/test_qt_main_window.py
+++ b/tests/test_qt_main_window.py
@@ -164,6 +164,53 @@ class MainWindowTests(unittest.TestCase):
         self.assertEqual(win._pending_badge.text(), "1")
         self.assertIn("ativa", win._pending_badge.toolTip())
 
+    # -- capa viva (#80): agrupamento, chips, checkbox real, badge ao vivo -------
+    def test_group_by_note_agrupa_preservando_ordem(self):
+        from scriba.qt.main_window import _group_by_note
+        groups = _group_by_note([
+            {"note_path": "/a.md", "text": "1"},
+            {"note_path": "/a.md", "text": "2"},
+            {"note_path": "/b.md", "text": "3"},
+        ])
+        self.assertEqual([g[0]["note_path"] for g in groups], ["/a.md", "/b.md"])
+        self.assertEqual([len(g[1]) for g in groups], [2, 1])
+
+    def test_short_date(self):
+        from scriba.qt.main_window import _short_date
+        self.assertEqual(_short_date("2026-07-04T09:15:00"), "04/07")
+        self.assertEqual(_short_date(""), "")
+
+    def test_render_home_agrupa_por_reuniao(self):
+        win = self._win()
+        data = {"total": 3, "seconds": 0, "clients": 2, "recent": [], "pending": [
+            {"text": "X1", "title": "Reunião A", "client": "ACME", "note_path": "/a.md",
+             "label": "BLOQUEANTE", "key": "", "folder": "", "started_at": "2026-07-04T09:00:00"},
+            {"text": "X2", "title": "Reunião A", "client": "ACME", "note_path": "/a.md",
+             "label": "ABERTO", "key": "", "folder": "", "started_at": "2026-07-04T09:00:00"},
+            {"text": "Y1", "title": "Reunião B", "client": "Globex", "note_path": "/b.md",
+             "label": "", "key": "", "folder": "", "started_at": "2026-07-03T09:00:00"},
+        ]}
+        win._render_home(data)
+        self.assertEqual(win._pending_lay.count(), 2)   # 2 reuniões, não 3 subtítulos
+        self.assertEqual(win._pending_badge.text(), "3")
+
+    def test_label_chip_cores_e_vazio(self):
+        win = self._win()
+        self.assertIsNone(win._label_chip(""))
+        self.assertEqual(win._label_chip("BLOQUEANTE — Eu").text(), "BLOQUEANTE")
+        self.assertEqual(win._label_chip("ABERTO").text(), "ABERTO")
+        self.assertEqual(win._label_chip("Indefinido").text(), "INDEFINIDO")  # neutro, não quebra
+
+    def test_bump_pending_badge_nao_fica_negativo(self):
+        win = self._win()
+        win._pending_active_n = 2
+        win._pending_badge.setVisible(True)
+        win._bump_pending_badge(-1)
+        self.assertEqual(win._pending_badge.text(), "1")
+        win._bump_pending_badge(-5)
+        self.assertEqual(win._pending_badge.text(), "0")
+        self.assertFalse(win._pending_badge.isVisible())
+
     def test_restyle_theme_nao_retem_acento_do_tema_anterior(self):
         """Regressão do bug #70 (bordas laranjas): trocar de tema a quente deve
         re-estilizar a capa; o acento do tema anterior NÃO pode sobrar na borda do card

--- a/tests/test_qt_main_window.py
+++ b/tests/test_qt_main_window.py
@@ -137,6 +137,33 @@ class MainWindowTests(unittest.TestCase):
         win._open_recent("")
         self.assertIsNone(win.app.notes_opened)
 
+    # -- recorte de 30 dias (#79): ativas vs backlog "M antigas" ----------------
+    def test_started_within_recorte_por_data(self):
+        from scriba.qt.main_window import _started_within
+        cutoff = "2026-06-05T12:00:00"
+        self.assertTrue(_started_within({"started_at": "2026-06-30T09:00:00"}, cutoff))   # recente
+        self.assertFalse(_started_within({"started_at": "2026-03-01T09:00:00"}, cutoff))  # antiga
+        self.assertFalse(_started_within({"started_at": ""}, cutoff))                     # sem data = antiga
+        self.assertFalse(_started_within({}, cutoff))
+
+    def test_render_home_badge_antigas_linka_e_some_sem_backlog(self):
+        win = self._win()
+        data = dict(self._DADOS, pending_stale=42, pending_days=30)
+        win._render_home(data)
+        # 1 item ativo + 1 rótulo "42 antiga(s)" (o último widget do layout)
+        self.assertEqual(win._pending_lay.count(), 2)
+        last = win._pending_lay.itemAt(win._pending_lay.count() - 1).widget()
+        self.assertIn("42 antiga", last.text())
+        # sem backlog: só o item ativo (o rótulo não ocupa espaço → sem layout shift)
+        win._render_home(dict(self._DADOS, pending_stale=0, pending_days=30))
+        self.assertEqual(win._pending_lay.count(), 1)
+
+    def test_render_home_badge_ativas_tooltip(self):
+        win = self._win()
+        win._render_home(dict(self._DADOS, pending_stale=0, pending_days=30))
+        self.assertEqual(win._pending_badge.text(), "1")
+        self.assertIn("ativa", win._pending_badge.toolTip())
+
     def test_restyle_theme_nao_retem_acento_do_tema_anterior(self):
         """Regressão do bug #70 (bordas laranjas): trocar de tema a quente deve
         re-estilizar a capa; o acento do tema anterior NÃO pode sobrar na borda do card

--- a/tests/test_qt_notes.py
+++ b/tests/test_qt_notes.py
@@ -278,15 +278,49 @@ class NotesSlice2Tests(unittest.TestCase):
         self.assertTrue(win._voice_btn.isVisibleTo(win))
         self.assertTrue(win._voice_btn.isEnabled())          # a gravação tem voices.json
 
-    def test_janela_pendencias_renderiza(self):
+    def _hub(self, groups):
         from scriba.qt.notes_ui import _ActionItemsWindow
 
+        app = type("A", (), {"cfg": type("C", (), {
+            "ui": type("U", (), {"pending_window_days": 30})()})()})()
+        self._revealed = []
+        w = _ActionItemsWindow(app, lambda: list(groups), self._revealed.append)
+        w.refresh()
+        return w
+
+    def _pend_group(self, folder):
+        return {"dt": datetime(2026, 7, 2, 15, 30), "title": "Boleto",
+                "path": folder / "n.md", "folder": folder, "client": "ACME",
+                "items": [
+                    {"key": "k1", "label": "BLOQUEANTE", "text": "corrigir CNPJ", "raw": "corrigir CNPJ"},
+                    {"key": "k2", "label": "ABERTO", "text": "enviar planilha", "raw": "enviar planilha"}]}
+
+    def test_hub_pendencias_renderiza_conta_ativas(self):
         folder = Path(tempfile.mkdtemp(prefix="scriba_qt_pend_"))
-        group = (datetime(2026, 7, 2, 15, 30), "Boleto", folder / "n.md", folder,
-                 [{"key": "k1", "label": "", "text": "corrigir CNPJ", "raw": "corrigir CNPJ"}])
-        revealed = []
-        w = _ActionItemsWindow([group], revealed.append)
-        self.assertIn("aberta", w._count.text())             # 1 item aberto
+        w = self._hub([self._pend_group(folder)])
+        self.assertIn("2 item", w._count.text())             # 2 ativas (default filtro Ativas)
+        self.assertGreaterEqual(w._client.count(), 2)        # "Todos os clientes" + ACME
+
+    def test_hub_filtro_bloqueantes(self):
+        folder = Path(tempfile.mkdtemp(prefix="scriba_qt_blk_"))
+        w = self._hub([self._pend_group(folder)])
+        w._set_filter("blocking")
+        self.assertIn("1 item", w._count.text())             # só o BLOQUEANTE
+        w._set_filter("archived")
+        self.assertIn("0 item", w._count.text())             # nada arquivado
+
+    def test_hub_busca_por_texto(self):
+        folder = Path(tempfile.mkdtemp(prefix="scriba_qt_bus_"))
+        w = self._hub([self._pend_group(folder)])
+        w._search.setText("planilha")
+        self.assertIn("1 item", w._count.text())             # casa só "enviar planilha"
+
+    def test_hub_clique_no_item_navega_ate_secao(self):
+        folder = Path(tempfile.mkdtemp(prefix="scriba_qt_nav_"))
+        g = self._pend_group(folder)
+        w = self._hub([g])
+        w._on_reveal_section(g["path"])                       # simula o clique
+        self.assertEqual(self._revealed, [g["path"]])
 
     def test_hint_de_pendencia_de_vozes_aparece_e_some_ao_rotular(self):
         from scriba.qt.notes_ui import NotesWindow

--- a/tests/test_qt_tray.py
+++ b/tests/test_qt_tray.py
@@ -39,6 +39,7 @@ class _FakeApp:
     # métodos chamados por ações (não exercitados no _sync)
     def show_main(self): pass
     def show_notes(self): pass
+    def show_action_hub(self, note_path=None): pass
     def show_log(self): pass
     def show_settings(self): pass
 
@@ -72,6 +73,15 @@ class TrayTests(unittest.TestCase):
         self.assertTrue(tray._act_speakers.isVisible())
         self.assertTrue(tray._spk_acts[3].isChecked())
         self.assertFalse(tray._spk_acts[1].isChecked())
+
+    def test_menu_tem_entrada_pendencias(self):
+        from scriba.qt.tray import Tray
+
+        tray = Tray(_FakeApp())
+        labels = [a.text() for a in tray._menu.actions()]
+        self.assertIn("Pendências", labels)
+        # posicionada junto de "Notas" (logo depois)
+        self.assertEqual(labels.index("Pendências"), labels.index("Notas") + 1)
 
     def test_set_recording_troca_icone_e_tooltip(self):
         from scriba.qt.tray import Tray


### PR DESCRIPTION
Implementa o épico **#75** (sistema de pendências como primeira classe) - 6 issues, um commit por issue. A pendência #81 (snooze) fica **de fora** por decisão (congelada, avaliar após ~3 semanas de uso real do hub).

## O que entra (na ordem dos commits)

- **#76 fundação** - tabela `action_items` no índice SQLite (schema v3), snapshot derivado; `meetings_index.set_action_state` + API `action_counts`/`list_action_items`.
- **#77 estados nomeados** - `.actions.json` passa a guardar open/done/dismissed/archived (retrocompat do bool legado); `set_action_state`, wrapper `set_action_done`, `archive_old_action_items`.
- **#79 recorte de 30 dias** - `ui.pending_window_days` (config + settings); capa conta só as **ativas** (últimos N dias) e mostra "M antigas" linkando p/ o hub.
- **#78 hub de 1ª classe** - reescreve a `_ActionItemsWindow`: filtros (ativas/bloqueantes/resolvidas/dispensadas/arquivadas), por cliente, busca, ordenação, chips coloridos, "arquivar antigas", clique no item abre a nota rolada na seção; `remember_geometry` + `restyle_theme`; `app.show_action_hub`.
- **#80 capa viva** - checkbox real (mata a affordance falsa), agrupamento por reunião, chips de label, tooltip, dispensar ✕, badge ao vivo sem re-render.
- **#82 roteamento** - capa (abrir/item/cabeçalho/+N outras) e bandeja ("Pendências") abrem o hub no contexto certo.

## Arquitetura

O `.actions.json` por pasta segue a **fonte da verdade** do estado; o índice é cache **derivado e reconstruível** (invariante do projeto). Limiar único (`pending_window_days`) compartilhado entre o recorte da capa e o "arquivar antigas".

## Testes

Suíte **506 verde** (era 468). Cobertura nova: índice (populamento/cascata/tombstone/paridade), estados+retrocompat+arquivamento, config round-trip, recorte da capa, hub (render/filtros/busca/navegação), capa viva (agrupamento/chips/badge), roteamento capa+bandeja. Sem dependência nova.

## Validação pendente

Falta a validação **ao vivo na tela** (hub, capa viva, troca de tema a quente) - não rodei o app sozinho. Recomendo revisar visualmente antes do merge. Um épico de testes (E2E/UI) será aberto em seguida.

Closes #75
