### PR TITLE
Testes do sistema de pendências: robustez do índice + lacunas (#84)

### DIFF
--- a/scriba/meetings_index.py
+++ b/scriba/meetings_index.py
@@ -23,8 +23,16 @@ from . import util
 
 log = logging.getLogger("scriba.meetings_index")
 
-DB_PATH = util.APP_DIR / "index.db"
+# Caminho do índice. Por padrão (None) é RESOLVIDO dinamicamente de `util.APP_DIR` a cada
+# conexão (`_db_path`), então isolar `util.APP_DIR` num teste já redireciona o índice —
+# sem isto, um teste que esquecesse de setar DB_PATH gravaria no index.db REAL do usuário
+# (o path era capturado no import). Setar DB_PATH explicitamente ainda funciona (override).
+DB_PATH = None
 SCHEMA_VERSION = 3  # v3 (#76): pendências (action items) viram snapshot no índice
+
+
+def _db_path() -> Path:
+    return DB_PATH if DB_PATH is not None else util.APP_DIR / "index.db"
 
 # Separa o resumo da transcrição completa no notas.md. AMBOS entram no FTS (v2/#11):
 # o resumo na coluna `body`, a transcrição na coluna `transcript` — assim a busca do
@@ -88,7 +96,7 @@ _DDL = (
 
 def _connect() -> sqlite3.Connection:
     util.ensure_app_dirs()
-    conn = sqlite3.connect(str(DB_PATH))
+    conn = sqlite3.connect(str(_db_path()))
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys = ON")
     conn.execute("PRAGMA busy_timeout = 5000")  # 2 workers finalizando juntos: espera o lock

--- a/tests/test_meetings_index.py
+++ b/tests/test_meetings_index.py
@@ -25,6 +25,8 @@ class MeetingsIndexTests(unittest.TestCase):
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp(prefix="scriba_idx_"))
         # isolamento total: índice e store de voz em tempdir
+        self._app0, self._logs0, self._store0, self._db0 = (
+            util.APP_DIR, util.LOGS_DIR, speakers.STORE_PATH, mi.DB_PATH)
         util.APP_DIR = self.tmp / "app"
         util.LOGS_DIR = util.APP_DIR / "logs"
         speakers.STORE_PATH = util.APP_DIR / "speakers.json"
@@ -33,6 +35,9 @@ class MeetingsIndexTests(unittest.TestCase):
         self.rec.mkdir(parents=True)
 
     def tearDown(self):
+        # restaura os globais (DB_PATH volta a None → resolução dinâmica p/ testes seguintes)
+        util.APP_DIR, util.LOGS_DIR, speakers.STORE_PATH, mi.DB_PATH = (
+            self._app0, self._logs0, self._store0, self._db0)
         shutil.rmtree(self.tmp, ignore_errors=True)
 
     # -- helper: cria uma pasta de gravação (meta.json + notas.md) -----------
@@ -437,6 +442,39 @@ class MeetingsIndexTests(unittest.TestCase):
         parse_open = {i["key"] for i in notes.parse_action_items(
             (a / "notas.md").read_text(encoding="utf-8"))}  # nenhum resolvido ainda
         self.assertEqual(idx_open, parse_open)
+
+
+class IndexPathIsolationTests(unittest.TestCase):
+    """Rede de segurança (#84): com DB_PATH None (default), o índice é RESOLVIDO de
+    util.APP_DIR — isolar só o APP_DIR já redireciona, então nenhum teste toca o
+    index.db REAL do usuário por esquecer de setar mi.DB_PATH."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="scriba_idxiso_"))
+        self._app0, self._logs0, self._db0 = util.APP_DIR, util.LOGS_DIR, mi.DB_PATH
+        util.APP_DIR = self.tmp / "app"
+        util.LOGS_DIR = util.APP_DIR / "logs"
+        mi.DB_PATH = None   # SEM override explícito: deve resolver de util.APP_DIR
+
+    def tearDown(self):
+        util.APP_DIR, util.LOGS_DIR, mi.DB_PATH = self._app0, self._logs0, self._db0
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_db_path_resolve_de_app_dir(self):
+        self.assertEqual(mi._db_path(), util.APP_DIR / "index.db")
+
+    def test_index_writer_grava_sob_app_dir_isolado(self):
+        rec = self.tmp / "rec" / "m"
+        rec.mkdir(parents=True)
+        (rec / "meta.json").write_text(
+            '{"status":"done","started_at":"2026-06-10T09:00:00"}', encoding="utf-8")
+        (rec / "notas.md").write_text("# X\n\n## Resumo\nok\n", encoding="utf-8")
+        self.assertTrue(mi.index_meeting(rec))
+        self.assertEqual(mi.count(), 1)
+        # o índice nasceu SOB o APP_DIR isolado (tmp), nunca no path real
+        db = util.APP_DIR / "index.db"
+        self.assertTrue(db.exists())
+        self.assertTrue(str(db).startswith(str(self.tmp)))
 
 
 if __name__ == "__main__":

--- a/tests/test_meetings_index.py
+++ b/tests/test_meetings_index.py
@@ -375,6 +375,20 @@ class MeetingsIndexTests(unittest.TestCase):
         by_key = {r["key"]: r["state"] for r in self._action_rows(f)}
         self.assertEqual(by_key[key], "open")
 
+    def test_set_action_state_reflete_dismissed_e_archived(self):
+        f = self._make_meeting("a", started_at="2026-06-10T09:00:00", pendencias=[
+            "**[BLOQUEANTE]** X1", "**[ABERTO]** X2"])
+        mi.index_meeting(f)
+        keys = [i["key"] for i in notes.parse_action_items(
+            (f / "notas.md").read_text(encoding="utf-8"))]
+        notes.set_action_state(f, keys[0], "dismissed")
+        notes.set_action_state(f, keys[1], "archived")
+        by = {r["key"]: r["state"] for r in self._action_rows(f)}
+        self.assertEqual((by[keys[0]], by[keys[1]]), ("dismissed", "archived"))
+        # contagens e filtros do índice enxergam os estados novos (nenhum 'open' sobra)
+        self.assertEqual(mi.action_counts(), {"dismissed": 1, "archived": 1})
+        self.assertEqual([i["text"] for i in mi.list_action_items(state="dismissed")], ["X1"])
+
     def test_set_action_state_resiliente_a_indice_indisponivel(self):
         # índice quebrado NÃO pode derrubar o set_action_done nem perder o .actions.json
         f = self._make_meeting("a", started_at="2026-06-10T09:00:00",

--- a/tests/test_qt_notes.py
+++ b/tests/test_qt_notes.py
@@ -25,6 +25,35 @@ _NOTE_MD = (
 )
 
 
+_MODULE_ISO = None
+
+
+def setUpModule():
+    # Robustez (#84): vários testes constroem NotesWindow, cujo show() dispara uma thread
+    # de reindex_if_needed. Com DB_PATH dinâmico, isolar APP_DIR/DB_PATH no módulo inteiro
+    # manda TODO acesso ao índice (sync e da thread) p/ um tmp — nenhum teste toca o
+    # index.db REAL do usuário (o bug que zerava a capa).
+    global _MODULE_ISO
+    from scriba import meetings_index as _mi
+    from scriba import util as _util
+    tmp = Path(tempfile.mkdtemp(prefix="scriba_qtnotes_app_"))
+    _MODULE_ISO = (_util.APP_DIR, _util.LOGS_DIR, _mi.DB_PATH, tmp)
+    _util.APP_DIR = tmp / "app"
+    _util.LOGS_DIR = _util.APP_DIR / "logs"
+    _mi.DB_PATH = None   # None = resolve de util.APP_DIR (agora o tmp isolado)
+
+
+def tearDownModule():
+    if _MODULE_ISO is None:
+        return
+    import shutil
+    from scriba import meetings_index as _mi
+    from scriba import util as _util
+    app0, logs0, db0, tmp = _MODULE_ISO
+    _util.APP_DIR, _util.LOGS_DIR, _mi.DB_PATH = app0, logs0, db0
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
 @unittest.skipUnless(_HAS_PYSIDE, "PySide6 não instalado (extra 'qt')")
 class PureHelperTests(unittest.TestCase):
     def test_note_info_le_frontmatter(self):
@@ -321,6 +350,44 @@ class NotesSlice2Tests(unittest.TestCase):
         w = self._hub([g])
         w._on_reveal_section(g["path"])                       # simula o clique
         self.assertEqual(self._revealed, [g["path"]])
+
+    def test_hub_focus_meeting_nao_quebra_sem_grupo(self):
+        # focar uma reunião que não está na lista atual não pode levantar (best-effort)
+        folder = Path(tempfile.mkdtemp(prefix="scriba_qt_foc_"))
+        w = self._hub([self._pend_group(folder)])
+        w.focus_meeting(str(folder / "inexistente.md"))       # header não existe → no-op silencioso
+        w.focus_meeting(str((folder / "n.md")))               # header existe → rola sem erro
+
+    def test_reveal_note_at_section_posiciona_cursor_na_secao(self):
+        from scriba import meetings_index as _mi
+        from scriba import util as _util
+        from scriba.qt.notes_ui import NotesWindow
+
+        base = Path(tempfile.mkdtemp(prefix="scriba_qt_sec_"))
+        # DB_PATH dinâmico (#84): isolar APP_DIR já manda o índice p/ o tmp
+        app0, logs0 = _util.APP_DIR, _util.LOGS_DIR
+        _util.APP_DIR = base / "app"; _util.LOGS_DIR = _util.APP_DIR / "logs"
+        self.addCleanup(lambda: (setattr(_util, "APP_DIR", app0),
+                                 setattr(_util, "LOGS_DIR", logs0)))
+        self.assertTrue(str(_mi._db_path()).startswith(str(base)))  # índice no tmp, não no real
+        note = base / "2026-07-02_15-30_Boleto.md"
+        note.write_text("# Boleto\n\n## Resumo\ntexto do resumo\n\n"
+                        "## Pendências e Ações\n- **[ABERTO]** corrigir CNPJ\n", encoding="utf-8")
+
+        class _Out:
+            def resolved_export_dir(_s): return base
+            def resolved_recordings_dir(_s): return base / "_rec"
+
+        class _App:
+            cfg = type("C", (), {"output": _Out()})()
+            def ui(_s, fn): fn()
+
+        win = NotesWindow(_App())
+        win._ensure_index_async = lambda: None   # sem thread de reindex (evita corrida APP_DIR)
+        win._refresh_list()
+        win.reveal_note_at_section(note)
+        self.assertEqual(win._selected()[0], note)                      # nota selecionada
+        self.assertIn("Pendências", win._view.textCursor().selectedText())  # cursor na seção
 
     def test_hint_de_pendencia_de_vozes_aparece_e_some_ao_rotular(self):
         from scriba.qt.notes_ui import NotesWindow


### PR DESCRIPTION
Primeira leva do épico de testes #84 - a parte **automatizável**. A validação E2E ao vivo (seção 1 do #84) fica para o Allan na tela.

## O que entra

**Robustez (fecha a classe do bug que zerou a capa):**
- `meetings_index.DB_PATH` vira override opcional (default `None`); `_db_path()` resolve o índice dinamicamente de `util.APP_DIR` no `_connect`. **Isolar `APP_DIR` num teste passa a bastar** - antes o path era capturado no import, então um teste que esquecesse de setar `mi.DB_PATH` gravava no `index.db` REAL.
- Guarda `IndexPathIsolationTests`: prova que com `DB_PATH=None` e só `APP_DIR` isolado, os writers gravam sob o tmp, nunca no real.
- `setUpModule`/`tearDownModule` em `test_qt_notes` isolam `APP_DIR`/`DB_PATH` do módulo inteiro - vários testes constroem `NotesWindow`, cujo `show()` dispara uma thread de `reindex_if_needed`; sem isolar, a corrida com a restauração do `APP_DIR` chegava a apagar as reuniões reais.

**Lacunas de teste:**
- `set_action_state` reflete `dismissed`/`archived` no snapshot do índice.
- `NotesWindow.reveal_note_at_section` posiciona o cursor na seção "Pendências e Ações".
- `_ActionItemsWindow.focus_meeting` é best-effort (não quebra sem grupo).

## Verificação

Suíte **511 verde**. Rodei a suíte 2x com guarda de `mtime`/contagem do `index.db` real: **inalterado** (46 reuniões preservadas) - a suíte não toca mais o índice do usuário.

## Ainda aberto no #84 (não neste PR)

- Validação E2E ao vivo (hub, capa viva, tema a quente) - precisa do Allan na tela.
- Migração da capa para consumir o índice (`_collect_home` ainda parseia `.md`) - candidato a issue própria.
