### PR TITLE
fix(update): reinício pós-update intermitente - retry no mutex + logging (#74)

### DIFF
--- a/scriba/main.py
+++ b/scriba/main.py
@@ -29,10 +29,33 @@ log = logging.getLogger("scriba")
 _mutex_handle = None  # mantém o handle vivo durante o processo
 
 
-def _single_instance() -> bool:
+_MUTEX_NAME = "Local\\ScribaDevSingleInstance"
+
+
+def _single_instance(retries: int = 0, delay: float = 0.4, name: str = _MUTEX_NAME) -> bool:
+    """True se esta é a única instância (adquiriu o mutex nomeado `name`).
+
+    Se o mutex já existe e `retries` > 0, FECHA o handle e tenta de novo após `delay` s
+    até `retries` vezes. Isso conserta o reinício pós-update intermitente (#74): o
+    relançamento pode chegar enquanto a instância ANTERIOR ainda está no teardown
+    (encerra por `os._exit` em até 3 s) segurando o mutex — sem o retry a nova instância
+    via ERROR_ALREADY_EXISTS e abortava calada, então o app "não reabria sozinho".
+
+    Importante: quando o mutex já existe, CreateMutexW devolve um handle para o mutex
+    EXISTENTE; segurá-lo manteria o objeto vivo e o retry nunca veria a liberação — por
+    isso fechamos o handle antes de reesperar."""
     global _mutex_handle
-    _mutex_handle = ctypes.windll.kernel32.CreateMutexW(None, False, "Local\\ScribaDevSingleInstance")
-    return ctypes.windll.kernel32.GetLastError() != 183  # ERROR_ALREADY_EXISTS
+    k32 = ctypes.windll.kernel32
+    for attempt in range(retries + 1):
+        _mutex_handle = k32.CreateMutexW(None, False, name)
+        if k32.GetLastError() != 183:  # != ERROR_ALREADY_EXISTS → adquirimos
+            return True
+        if _mutex_handle:
+            k32.CloseHandle(_mutex_handle)
+            _mutex_handle = None
+        if attempt < retries:
+            time.sleep(delay)
+    return False
 
 
 # Evento nomeado que a 2ª instância usa para pedir "mostre a janela" à 1ª —
@@ -521,11 +544,23 @@ class ScribaApp:
         pyw = Path(sys.executable)
         if pyw.name.lower() == "python.exe":
             pyw = pyw.with_name("pythonw.exe")  # sem janela de console
-        ps = (f"Wait-Process -Id {os.getpid()} -Timeout 60 -ErrorAction SilentlyContinue; "
-              f"Start-Process '{pyw}' -ArgumentList '-m','scriba.cli','run'")
+        # PS que espera este processo sair (libera o mutex) e sobe a nova instância.
+        # Marca SCRIBA_RELAUNCHED p/ a nova instância dar retry no single-instance (#74),
+        # e LOGA cada passo — antes a falha do Start-Process era 100% silenciosa.
+        ps = ("$ErrorActionPreference='Continue'; "
+              f"Write-Output ('[' + (Get-Date -Format s) + '] relaunch: aguardando pid {os.getpid()} sair'); "
+              f"Wait-Process -Id {os.getpid()} -Timeout 60 -ErrorAction SilentlyContinue; "
+              "$env:SCRIBA_RELAUNCHED='1'; "
+              "Write-Output 'relaunch: subindo nova instancia'; "
+              f"try {{ Start-Process '{pyw}' -ArgumentList '-m','scriba.cli','run' -ErrorAction Stop; "
+              "Write-Output 'relaunch: Start-Process OK' } "
+              "catch { Write-Output ('relaunch: Start-Process FALHOU - ' + $_.Exception.Message) }")
         try:
+            util.ensure_app_dirs()
+            logf = open(util.LOGS_DIR / "relaunch.log", "a", encoding="utf-8")
             subprocess.Popen(
                 ["powershell", "-NoProfile", "-WindowStyle", "Hidden", "-Command", ps],
+                stdout=logf, stderr=subprocess.STDOUT,
                 creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0)
                 | getattr(subprocess, "DETACHED_PROCESS", 0),
             )
@@ -1020,7 +1055,11 @@ def run_app(minimized: bool = False) -> int:
     # do atalho do IDLE; precisa vir antes de qualquer janela
     util.set_explicit_app_id()
     _setup_logging()
-    if not _single_instance():
+    # Reinício pós-update (#74): a instância antiga pode ainda estar no teardown segurando
+    # o mutex; damos alguns retries p/ ela liberar (o 2º-launch normal, do atalho, segue
+    # instantâneo — sem retry). Marcado pela env var setada no PS do relaunch.
+    relaunched = os.environ.get("SCRIBA_RELAUNCHED") == "1"
+    if not _single_instance(retries=10 if relaunched else 0):
         # clique no atalho com o app já vivo: pede à instância ativa que abra a
         # janela principal (antes a 2ª instância morria muda e "nada acontecia")
         if _signal_show_window():

--- a/tests/test_relaunch.py
+++ b/tests/test_relaunch.py
@@ -28,6 +28,8 @@ class RelaunchTests(unittest.TestCase):
     def test_agenda_relancamento_avisa_e_forca_saida(self):
         app = self._app()
         with mock.patch("subprocess.Popen") as popen, \
+                mock.patch("builtins.open", mock.mock_open()), \
+                mock.patch("scriba.main.util.ensure_app_dirs"), \
                 mock.patch("PySide6.QtWidgets.QMessageBox.information") as info, \
                 mock.patch("PySide6.QtWidgets.QMessageBox.warning") as warn, \
                 mock.patch("os._exit") as oexit, \
@@ -45,6 +47,9 @@ class RelaunchTests(unittest.TestCase):
             self.assertIn("Wait-Process", cmd)
             self.assertIn("Start-Process", cmd)
             self.assertIn("scriba.cli", cmd)
+            # #74: marca a nova instância p/ dar retry no single-instance e loga a saída
+            self.assertIn("SCRIBA_RELAUNCHED", cmd)
+            self.assertIn("stdout", popen.call_args.kwargs)  # PS redirecionado p/ log
             # pediu o quit gracioso
             app.request_quit.assert_called_once()
             # armou o watchdog de saída forçada: 3 s, daemon, chamando os._exit(0)
@@ -58,6 +63,8 @@ class RelaunchTests(unittest.TestCase):
     def test_falha_ao_agendar_avisa_sem_matar(self):
         app = self._app()
         with mock.patch("subprocess.Popen", side_effect=OSError("boom")), \
+                mock.patch("builtins.open", mock.mock_open()), \
+                mock.patch("scriba.main.util.ensure_app_dirs"), \
                 mock.patch("PySide6.QtWidgets.QMessageBox.information"), \
                 mock.patch("PySide6.QtWidgets.QMessageBox.warning") as warn, \
                 mock.patch("os._exit") as oexit, \
@@ -70,6 +77,52 @@ class RelaunchTests(unittest.TestCase):
             app.request_quit.assert_not_called()
             self.assertFalse(timer.called)
             oexit.assert_not_called()
+
+
+@unittest.skipUnless(sys.platform == "win32", "mutex nomeado é específico do Windows")
+class SingleInstanceRetryTests(unittest.TestCase):
+    """_single_instance com retry: conserta o reinício pós-update intermitente (#74) —
+    a nova instância espera a antiga liberar o mutex em vez de abortar de cara."""
+
+    def setUp(self):
+        import ctypes
+        import os
+        from scriba import main
+        self.main = main
+        self.k32 = ctypes.windll.kernel32
+        # nome ÚNICO por processo: não colide com o mutex do app real que pode estar vivo
+        self.name = f"Local\\ScribaDevTest_{os.getpid()}"
+        main._mutex_handle = None
+
+    def tearDown(self):
+        if self.main._mutex_handle:
+            self.k32.CloseHandle(self.main._mutex_handle)
+            self.main._mutex_handle = None
+
+    def test_sem_retry_falha_de_cara_com_mutex_preso(self):
+        held = self.k32.CreateMutexW(None, False, self.name)  # simula instância anterior
+        try:
+            self.assertFalse(self.main._single_instance(retries=0, name=self.name))
+        finally:
+            self.k32.CloseHandle(held)
+
+    def test_retry_espera_mas_falha_se_nunca_libera(self):
+        held = self.k32.CreateMutexW(None, False, self.name)
+        try:
+            self.assertFalse(self.main._single_instance(retries=3, delay=0.01, name=self.name))
+        finally:
+            self.k32.CloseHandle(held)
+
+    def test_adquire_quando_livre(self):
+        self.assertTrue(self.main._single_instance(retries=2, delay=0.01, name=self.name))
+        self.assertIsNotNone(self.main._mutex_handle)  # segura o handle no sucesso
+
+    def test_retry_adquire_apos_liberacao(self):
+        # a instância anterior segura o mutex e o solta durante os retries → adquire
+        import threading
+        held = self.k32.CreateMutexW(None, False, self.name)
+        threading.Timer(0.05, lambda: self.k32.CloseHandle(held)).start()
+        self.assertTrue(self.main._single_instance(retries=30, delay=0.02, name=self.name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Corrige o reinício automático pós-update que falhava de forma intermitente (reportado pelo @jairoldc, recorrência de causa diferente da #21).

## Diagnóstico

Duas formas prováveis da falha "fecha e não reabre sozinho":

1. **Corrida do mutex de instância única (causa raiz mais provável).** O `relaunch()` sobe a nova instância (`Start-Process`) assim que o `Wait-Process` vê o processo antigo sair. Mas a instância antiga pode ainda estar no teardown (encerra por `os._exit` em até 3s) **segurando o mutex**. Sem retry, a nova instância via `ERROR_ALREADY_EXISTS` no `_single_instance` e **abortava calada** → "não reabriu sozinho". A intermitência bate com uma corrida de timing.
2. **Falha silenciosa do `Start-Process`.** O PS rodava `-WindowStyle Hidden` sem log; qualquer falha (antivírus, path) era invisível (o próprio Jairo pediu logging).

## Correção

- `_single_instance(retries, delay, name)`: a instância **relançada** (marcada pela env var `SCRIBA_RELAUNCHED`, setada no PS do relaunch) espera o mutex liberar (~4s, cobre o watchdog de 3s da instância antiga). O 2º-launch normal (atalho) segue **instantâneo**. Detalhe crítico: ao ver `ALREADY_EXISTS`, fecha o handle antes de reesperar (senão manteria o mutex vivo e o retry nunca veria a liberação).
- PS do relaunch loga cada passo em `logs/relaunch.log` e o `Start-Process` vai num `try/catch` que registra o motivo — **fim da falha silenciosa**.

## Validação

- Reprodução determinística da corrida não é viável (é timing), então: (a) **testei o retry** com um mutex nomeado real (`SingleInstanceRetryTests`: sem-retry-falha / retry-espera-mas-falha / adquire-livre / **adquire-após-liberação**); (b) **rodei o PS gerado** e confirmei que o `catch` dispara e loga `"Start-Process FALHOU - ..."` quando o Start-Process falha (a exata falha silenciosa de antes).
- Suíte **515 verde**.

## Nota

Como o release é entregue por auto-update, esta correção + o `relaunch.log` já passam a valer na **próxima** atualização - se ainda falhar, teremos o log para ver o porquê.

Closes #74
