### PR TITLE
Port multiplataforma: app importa no Linux (#96)

### DIFF
--- a/scriba/detector.py
+++ b/scriba/detector.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import logging
 import re
 import time
-import winreg
 from enum import Enum
 from typing import Callable
 
@@ -75,6 +74,10 @@ def _iter_mic_keys():
     o app está com o mic aberto. LastUsedTimeStart é reescrito toda vez que o app
     REABRE o mic — é o sinal de fronteira entre duas calls consecutivas (#34).
     """
+    # lazy: winreg só existe no Windows; o import no topo quebrava o módulo (e a
+    # cadeia scriba.main) em Linux/macOS antes de qualquer código rodar (#96)
+    import winreg
+
     for base in (_BASE, _BASE + r"\NonPackaged"):
         try:
             root = winreg.OpenKey(winreg.HKEY_CURRENT_USER, base)

--- a/scriba/main.py
+++ b/scriba/main.py
@@ -775,7 +775,7 @@ class ScribaApp:
 
         folder = Path(folder)
         log.info("processando %s (subprocesso)", folder.name)
-        python = Path(sys.prefix) / "Scripts" / "python.exe"
+        python = util.console_python()
         args = [str(python), "-X", "utf8", "-m", "scriba.cli", "process", str(folder)]
         meta_path = folder / "meta.json"
         log_path = folder / "process.log"
@@ -791,7 +791,7 @@ class ScribaApp:
                 args,
                 stdout=out if out is not None else subprocess.DEVNULL,
                 stderr=subprocess.STDOUT if out is not None else subprocess.DEVNULL,
-                creationflags=subprocess.CREATE_NO_WINDOW,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
             )
         except Exception:
             log.exception("não consegui iniciar o subprocesso de %s", folder.name)

--- a/scriba/notify.py
+++ b/scriba/notify.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import winreg
 from pathlib import Path
 
 from . import util
@@ -14,6 +13,10 @@ _DISPLAY = "ScribaDev"
 def _register_aumid() -> None:
     """Registra o AUMID em HKCU (sem admin) — dá nome e ícone próprios aos toasts
     e permite que cliques a partir da Central de Ações cheguem ao app."""
+    # lazy: winreg só existe no Windows; o import no topo quebrava o módulo em
+    # Linux/macOS (#96) — este caminho só roda dentro do Notifier (Windows-only)
+    import winreg
+
     key_path = rf"SOFTWARE\Classes\AppUserModelId\{AUMID}"
     with winreg.CreateKey(winreg.HKEY_CURRENT_USER, key_path) as k:
         winreg.SetValueEx(k, "DisplayName", 0, winreg.REG_SZ, _DISPLAY)

--- a/scriba/util.py
+++ b/scriba/util.py
@@ -208,13 +208,25 @@ def open_path(path) -> None:
     subprocess.Popen(["explorer.exe", str(path)])
 
 
+def console_python() -> Path:
+    """python de CONSOLE do venv para subprocessos (não o pythonw da GUI).
+
+    No Windows a GUI roda sob pythonw.exe e sys.executable herdaria a falta de
+    console (pipes/encoding quebram) — por isso o python.exe irmão em Scripts/.
+    No POSIX não existe essa distinção (nem Scripts/): sys.executable resolve (#96).
+    """
+    if sys.platform == "win32":
+        return Path(sys.prefix) / "Scripts" / "python.exe"
+    return Path(sys.executable)
+
+
 def _audio_probe(extra_args: list[str], timeout: float) -> dict | None:
     """Roda a sonda de áudio (scriba.audioprobe) num subprocesso descartável — o
     PortAudio pode abortar o processo com assert de CRT ao enumerar. None se falhar."""
     import json
     import subprocess
 
-    python = Path(sys.prefix) / "Scripts" / "python.exe"
+    python = console_python()
     try:
         proc = subprocess.run(
             [str(python), "-X", "utf8", "-m", "scriba.audioprobe", *extra_args],
@@ -223,7 +235,7 @@ def _audio_probe(extra_args: list[str], timeout: float) -> dict | None:
             encoding="utf-8",
             errors="replace",
             timeout=timeout,
-            creationflags=subprocess.CREATE_NO_WINDOW,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
         if proc.returncode == 0 and proc.stdout.strip():
             return json.loads(proc.stdout.strip().splitlines()[-1])

--- a/tests/test_posix_import.py
+++ b/tests/test_posix_import.py
@@ -1,0 +1,58 @@
+"""#96: a cadeia de import do app não pode depender de módulos Windows-only.
+
+Simula o ambiente Linux num subprocesso: bloqueia winreg (builtin que só existe
+no Windows) e pyaudiowpatch/windows-toasts (fora do Windows nem instalam, pelos
+markers do #95) e importa a cadeia completa. Se alguém reintroduzir um import
+desses no topo de um módulo, este teste quebra já no CI Windows — sem esperar
+o job Linux (#103).
+"""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+_SIM = """
+import sys
+
+BLOCKED = {"winreg", "pyaudiowpatch", "windows_toasts"}
+
+
+class LinuxSim:
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in BLOCKED:
+            raise ImportError(f"modulo bloqueado (simulando Linux): {name}")
+        return None
+
+
+sys.meta_path.insert(0, LinuxSim())
+
+import scriba.main
+import scriba.cli
+import scriba.detector
+import scriba.notify
+import scriba.pipeline
+
+print("OK")
+"""
+
+
+class TestImportSemModulosWindows(unittest.TestCase):
+    def test_cadeia_de_import_sem_modulos_windows(self):
+        proc = subprocess.run(
+            [sys.executable, "-X", "utf8", "-c", _SIM],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=str(REPO),
+            timeout=120,
+        )
+        self.assertEqual(proc.returncode, 0, msg=f"stderr:\n{proc.stderr}")
+        self.assertIn("OK", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Segundo degrau do epico #104 - fixes minimos, in-place (a camada scriba/plat/ nasce na #97).

**O que muda**
- `import winreg` vira lazy dentro de `detector._iter_mic_keys` e `notify._register_aumid` (no topo do modulo, quebrava `import scriba.main` em Linux/macOS).
- `creationflags=subprocess.CREATE_NO_WINDOW` -> `getattr(subprocess, "CREATE_NO_WINDOW", 0)` em `util._audio_probe` e no subprocesso de processamento do `main` (AttributeError fora do Windows).
- Novo `util.console_python()`: no win32 mantem `Scripts/python.exe` (comportamento atual - a GUI roda sob pythonw e o subprocesso precisa do python de console); no POSIX usa `sys.executable`.
- `theme.py` conferido: ja degrada para tema escuro fora do Windows (nenhuma mudanca).

**Validacao**
- Simulacao do Linux no Windows: subprocesso bloqueando `winreg`/`pyaudiowpatch`/`windows_toasts` importa `scriba.main/cli/detector/notify/pipeline` com sucesso - agora versionada como teste de regressao (`tests/test_posix_import.py`), que pega reincidencia ja no CI Windows.
- Suite completa verde no Windows (585 testes, OK) + teste novo passando.

Closes #96