### PR TITLE
Port multiplataforma: camada scriba/plat/ + paths por SO (#97)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,9 @@ scribadev = "scriba.cli:main"
 scribadev-tray = "scriba.cli:main_tray"
 
 [tool.setuptools]
-packages = ["scriba"]
+# subpacotes listados explicitamente: sem eles um build NÃO-editável (wheel/sdist)
+# omitiria scriba.qt/scriba.plat em silêncio (o editable de hoje mascara isso)
+packages = ["scriba", "scriba.plat", "scriba.qt"]
 
 # versão = fonte única em scriba/__init__.py (__version__); bump = editar lá só
 [tool.setuptools.dynamic]

--- a/scriba/config.py
+++ b/scriba/config.py
@@ -8,7 +8,7 @@ import tomllib
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-from . import util
+from . import plat, util
 
 log = logging.getLogger("scriba.config")
 
@@ -228,8 +228,12 @@ class Output:
         return util.APP_DIR / "Notas"
 
     def resolved_recordings_dir(self) -> Path:
-        """Pasta das gravações, criada na hora se não existir."""
-        d = Path(self.recordings_dir).expanduser() if self.recordings_dir else Path(r"C:\temp\scribadev\gravacoes")
+        """Pasta das gravações, criada na hora se não existir.
+
+        Default por SO via camada de plataforma (#104): no Windows segue o
+        C:\\temp\\scribadev\\gravacoes histórico; no POSIX cai sob o app_data_dir.
+        """
+        d = Path(self.recordings_dir).expanduser() if self.recordings_dir else plat.default_recordings_dir()
         d.mkdir(parents=True, exist_ok=True)
         return d
 

--- a/scriba/plat/__init__.py
+++ b/scriba/plat/__init__.py
@@ -1,0 +1,23 @@
+"""Camada de plataforma: despacho por SO (épico #104).
+
+Regra de ouro: no Windows o backend `_win` executa exatamente o código que o app
+sempre teve (movido, não reescrito) — só o ramo POSIX (`_posix`, Linux + macOS) é
+novo. Módulos de negócio não tocam winreg/ctypes.windll/explorer.exe diretamente:
+o que é específico de SO passa por aqui.
+
+Este pacote não importa outros módulos do scriba (util importa plat; o contrário
+criaria ciclo de import).
+"""
+
+from __future__ import annotations
+
+import sys
+
+if sys.platform == "win32":
+    from . import _win as _backend
+else:
+    from . import _posix as _backend
+
+app_data_dir = _backend.app_data_dir
+default_recordings_dir = _backend.default_recordings_dir
+open_path = _backend.open_path

--- a/scriba/plat/_posix.py
+++ b/scriba/plat/_posix.py
@@ -1,0 +1,37 @@
+"""Backend POSIX (Linux + macOS) da camada de plataforma (#104).
+
+Quando Linux e macOS divergirem de verdade (captura, notificações nativas),
+este módulo se divide em _linux.py/_mac.py; por ora os ramos por SO cabem aqui.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def app_data_dir() -> Path:
+    """Diretório de dados do app na convenção de cada SO.
+
+    Linux: $XDG_DATA_HOME/ScribaDev (fallback ~/.local/share/ScribaDev).
+    macOS: ~/Library/Application Support/ScribaDev.
+    """
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "ScribaDev"
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "share"
+    return base / "ScribaDev"
+
+
+def default_recordings_dir() -> Path:
+    """Fora do Windows não existe C:\\temp — as gravações ficam sob o app_data_dir."""
+    return app_data_dir() / "gravacoes"
+
+
+def open_path(path) -> None:
+    """Abre arquivo ou pasta no gerenciador do SO (xdg-open no Linux, open no macOS)."""
+    import subprocess
+
+    opener = "open" if sys.platform == "darwin" else "xdg-open"
+    subprocess.Popen([opener, str(path)])

--- a/scriba/plat/_win.py
+++ b/scriba/plat/_win.py
@@ -1,0 +1,32 @@
+"""Backend Windows da camada de plataforma — comportamento idêntico ao histórico.
+
+Código MOVIDO de util.py/config.py (não reescrito): qualquer mudança aqui é
+mudança de comportamento no Windows e precisa de justificativa própria (#104).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def app_data_dir() -> Path:
+    """%LOCALAPPDATA%\\ScribaDev (fallback: home) — o APP_DIR de sempre."""
+    return Path(os.environ.get("LOCALAPPDATA", str(Path.home()))) / "ScribaDev"
+
+
+def default_recordings_dir() -> Path:
+    """Default histórico das gravações (config [output] recordings_dir vazio)."""
+    return Path(r"C:\temp\scribadev\gravacoes")
+
+
+def open_path(path) -> None:
+    """Abre arquivo ou pasta no Explorer (substituto do os.startfile).
+
+    O winrt (toasts) inicializa o COM do processo em MTA, e o ShellExecute do
+    os.startfile falha em abrir pastas nesse modo ("o local não está
+    disponível"). O explorer.exe em processo próprio não tem esse problema.
+    """
+    import subprocess
+
+    subprocess.Popen(["explorer.exe", str(path)])

--- a/scriba/util.py
+++ b/scriba/util.py
@@ -16,9 +16,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import NamedTuple
 
+from . import plat
+
 log = logging.getLogger("scriba.util")
 
-APP_DIR = Path(os.environ.get("LOCALAPPDATA", str(Path.home()))) / "ScribaDev"
+# Diretório de dados por SO via camada de plataforma (#104). No Windows é o
+# %LOCALAPPDATA%\ScribaDev de sempre (plat._win); Linux/macOS em plat._posix.
+APP_DIR = plat.app_data_dir()
 LOGS_DIR = APP_DIR / "logs"
 CONFIG_PATH = APP_DIR / "config.toml"
 STATE_PATH = APP_DIR / "state.json"
@@ -197,15 +201,12 @@ def bootstrap_cuda_dlls() -> None:
 
 
 def open_path(path) -> None:
-    """Abre arquivo ou pasta no Explorer (substituto do os.startfile).
+    """Abre arquivo ou pasta no gerenciador do SO (Explorer / xdg-open / open).
 
-    O winrt (toasts) inicializa o COM do processo em MTA, e o ShellExecute do
-    os.startfile falha em abrir pastas nesse modo ("o local não está
-    disponível"). O explorer.exe em processo próprio não tem esse problema.
+    O porquê do explorer.exe em processo próprio no Windows (COM em MTA do
+    winrt) vive em plat._win.open_path (#104).
     """
-    import subprocess
-
-    subprocess.Popen(["explorer.exe", str(path)])
+    plat.open_path(path)
 
 
 def console_python() -> Path:

--- a/tests/test_plat.py
+++ b/tests/test_plat.py
@@ -1,0 +1,91 @@
+"""#97: camada de plataforma — paths por SO e despacho do backend.
+
+Os dois backends são importáveis em qualquer SO (só stdlib), então o POSIX é
+testado aqui mesmo no Windows, direto em scriba.plat._posix.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scriba import plat
+from scriba.plat import _posix, _win
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+class TestBackendWindows(unittest.TestCase):
+    def test_app_data_dir_usa_localappdata(self):
+        with mock.patch.dict(os.environ, {"LOCALAPPDATA": r"C:\Users\x\AppData\Local"}):
+            self.assertEqual(
+                _win.app_data_dir(), Path(r"C:\Users\x\AppData\Local") / "ScribaDev"
+            )
+
+    def test_app_data_dir_fallback_home(self):
+        env = {k: v for k, v in os.environ.items() if k != "LOCALAPPDATA"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(_win.app_data_dir(), Path.home() / "ScribaDev")
+
+    def test_default_recordings_dir_historico(self):
+        # invariante do épico #104: comportamento do Windows não muda
+        self.assertEqual(_win.default_recordings_dir(), Path(r"C:\temp\scribadev\gravacoes"))
+
+
+class TestBackendPosix(unittest.TestCase):
+    def test_linux_respeita_xdg_data_home(self):
+        with mock.patch.object(sys, "platform", "linux"), \
+                mock.patch.dict(os.environ, {"XDG_DATA_HOME": "/tmp/xdg"}):
+            self.assertEqual(_posix.app_data_dir(), Path("/tmp/xdg") / "ScribaDev")
+
+    def test_linux_fallback_local_share(self):
+        # XDG_DATA_HOME vazio = ausente (string vazia é falsy no get)
+        with mock.patch.object(sys, "platform", "linux"), \
+                mock.patch.dict(os.environ, {"XDG_DATA_HOME": ""}):
+            self.assertEqual(
+                _posix.app_data_dir(), Path.home() / ".local" / "share" / "ScribaDev"
+            )
+
+    def test_macos_application_support(self):
+        with mock.patch.object(sys, "platform", "darwin"):
+            self.assertEqual(
+                _posix.app_data_dir(),
+                Path.home() / "Library" / "Application Support" / "ScribaDev",
+            )
+
+    def test_default_recordings_sob_app_data(self):
+        with mock.patch.object(sys, "platform", "linux"), \
+                mock.patch.dict(os.environ, {"XDG_DATA_HOME": "/tmp/xdg"}):
+            self.assertEqual(
+                _posix.default_recordings_dir(), Path("/tmp/xdg") / "ScribaDev" / "gravacoes"
+            )
+
+
+class TestDespacho(unittest.TestCase):
+    def test_backend_casa_com_o_so_atual(self):
+        esperado = _win if sys.platform == "win32" else _posix
+        self.assertIs(plat.app_data_dir, esperado.app_data_dir)
+        self.assertIs(plat.default_recordings_dir, esperado.default_recordings_dir)
+        self.assertIs(plat.open_path, esperado.open_path)
+
+    def test_util_app_dir_vem_da_camada(self):
+        # em subprocesso limpo: outros testes da suíte patcham util.APP_DIR
+        # (isolamento do índice) e a ordem de execução não pode influenciar
+        code = (
+            "from scriba import plat, util; "
+            "assert util.APP_DIR == plat.app_data_dir(), (util.APP_DIR, plat.app_data_dir()); "
+            "print('OK')"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-X", "utf8", "-c", code],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            cwd=str(REPO), timeout=60,
+        )
+        self.assertEqual(proc.returncode, 0, msg=f"stderr:\n{proc.stderr}")
+        self.assertIn("OK", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Terceiro degrau do epico #104 - nasce a camada de abstracao de plataforma.

**O que muda**
- Novo pacote `scriba/plat/`: `__init__.py` despacha por `sys.platform`; `_win.py` e o codigo historico MOVIDO sem reescrita (regra de ouro do epico); `_posix.py` e o ramo novo (Linux + macOS).
- `APP_DIR` por SO: Windows segue `%LOCALAPPDATA%\ScribaDev`; Linux `$XDG_DATA_HOME/ScribaDev` (fallback `~/.local/share`); macOS `~/Library/Application Support/ScribaDev`.
- Default de gravacoes: Windows segue `C:\temp\scribadev\gravacoes`; POSIX cai sob o `app_data_dir`.
- `util.open_path` via camada: Explorer no Windows (racional do COM/MTA preservado em `_win`), `xdg-open`/`open` no POSIX.
- De passagem: `packages` do pyproject agora lista os subpacotes (`scriba.qt` ja era omitido em build nao-editavel; `scriba.plat` cairia no mesmo buraco).

**Validacao**
- `tests/test_plat.py` (10 testes): os dois backends sao puro stdlib e testaveis em qualquer SO - XDG com e sem fallback, macOS, LOCALAPPDATA com fallback, default historico de gravacoes, despacho do backend, e o invariante `util.APP_DIR == plat.app_data_dir()` em subprocesso limpo (imune aos patches de APP_DIR de outros testes).
- Suite completa verde no Windows: 595 testes, OK.

Closes #97