### PR TITLE
Port multiplataforma: guards de GPU/CUDA + doctor platform-aware (#98)

### DIFF
--- a/scriba/cli.py
+++ b/scriba/cli.py
@@ -355,20 +355,25 @@ def cmd_doctor(args) -> int:
         failures += 1
         cfg = None
 
-    # Imports nativos
-    for mod, why in [
-        ("pyaudiowpatch", "captura de áudio"),
+    # Imports nativos — pyaudiowpatch/windows_toasts só existem (e só instalam,
+    # pelos markers do #95) no Windows; fora dele são não-aplicáveis (#98)
+    native = [
         ("faster_whisper", "transcrição"),
         ("ctranslate2", "motor do Whisper"),
         ("pystray", "ícone de bandeja"),
-        ("windows_toasts", "notificações"),
-    ]:
+    ]
+    if sys.platform == "win32":
+        native = [("pyaudiowpatch", "captura de áudio"), *native, ("windows_toasts", "notificações")]
+    for mod, why in native:
         try:
             __import__(mod)
             _print(_OK, f"import {mod}")
         except Exception as e:
             _print(_FAIL, f"import {mod}", f"({why}) {e}")
             failures += 1
+    if sys.platform != "win32":
+        _print(_OK, "import pyaudiowpatch", "não se aplica neste SO (captura é Windows-only por ora)")
+        _print(_OK, "import windows_toasts", "não se aplica neste SO (toasts são Windows-only)")
 
     # CUDA
     try:
@@ -415,63 +420,71 @@ def cmd_doctor(args) -> int:
     except Exception as e:
         _print(_WARN, "Resumo (IA)", f"erro ao checar o provider ({e})")
 
-    # Registro dos apps monitorados
-    try:
-        from .detector import active_app, app_key_status, patterns_from
-
-        pats = patterns_from(cfg.detection) if cfg else ["teams"]
-        in_call = active_app(pats)
-        for name, exists in app_key_status(pats).items():
-            if name == in_call:
-                _print(_OK, f"Detecção {name}", "call ATIVA agora")
-            elif exists:
-                _print(_OK, f"Detecção {name}", "chave do registro OK")
-            else:
-                _print(_WARN, f"Detecção {name}", "sem chave ainda — entre numa call dele uma vez para o Windows criá-la")
-    except Exception as e:
-        _print(_FAIL, "Detecção de apps", str(e))
-        failures += 1
-
-    # Reuniões no navegador (Google Meet, Teams web...)
-    try:
-        from .detector import (
-            browser_key_status,
-            browser_patterns_from,
-            desktop_names_from,
-            title_patterns_from,
-            web_service_label,
-        )
-
-        bpats = browser_patterns_from(cfg.detection) if cfg else []
-        if bpats:
-            desktop = desktop_names_from(cfg.detection)
-            tpats = title_patterns_from(cfg.detection) if cfg else []
-            svcs = ", ".join(dict.fromkeys(web_service_label(t, desktop) for t in tpats)) or "qualquer site com mic"
-            ready = [b for b, ok in browser_key_status(bpats).items() if ok]
-            if ready:
-                _print(_OK, "Detecção no navegador", f"{svcs} — via {', '.join(ready)}")
-            else:
-                _print(_WARN, "Detecção no navegador", f"{svcs} — nenhum navegador usou o mic ainda; entre numa call (ex.: Meet) uma vez")
-        else:
-            _print(_OK, "Detecção no navegador", "desligada (browsers = \"\")")
-    except Exception as e:
-        _print(_WARN, "Detecção no navegador", str(e))
-
-    # Áudio
-    try:
-        import pyaudiowpatch as pyaudio
-
-        p = pyaudio.PyAudio()
+    # Registro dos apps monitorados — a detecção lê o ConsentStore do Windows;
+    # fora dele ainda não há detecção automática (#98; stubs na #102)
+    if sys.platform != "win32":
+        _print(_OK, "Detecção de calls", "não suportada neste SO ainda — use a gravação manual")
+    else:
         try:
-            mic = p.get_default_input_device_info()["name"]
-            lb = p.get_default_wasapi_loopback()["name"]
-        finally:
-            p.terminate()
-        _print(_OK, "Microfone padrão", mic)
-        _print(_OK, "Loopback padrão", lb)
-    except Exception as e:
-        _print(_FAIL, "Dispositivos de áudio", str(e))
-        failures += 1
+            from .detector import active_app, app_key_status, patterns_from
+
+            pats = patterns_from(cfg.detection) if cfg else ["teams"]
+            in_call = active_app(pats)
+            for name, exists in app_key_status(pats).items():
+                if name == in_call:
+                    _print(_OK, f"Detecção {name}", "call ATIVA agora")
+                elif exists:
+                    _print(_OK, f"Detecção {name}", "chave do registro OK")
+                else:
+                    _print(_WARN, f"Detecção {name}", "sem chave ainda — entre numa call dele uma vez para o Windows criá-la")
+        except Exception as e:
+            _print(_FAIL, "Detecção de apps", str(e))
+            failures += 1
+
+        # Reuniões no navegador (Google Meet, Teams web...)
+        try:
+            from .detector import (
+                browser_key_status,
+                browser_patterns_from,
+                desktop_names_from,
+                title_patterns_from,
+                web_service_label,
+            )
+
+            bpats = browser_patterns_from(cfg.detection) if cfg else []
+            if bpats:
+                desktop = desktop_names_from(cfg.detection)
+                tpats = title_patterns_from(cfg.detection) if cfg else []
+                svcs = ", ".join(dict.fromkeys(web_service_label(t, desktop) for t in tpats)) or "qualquer site com mic"
+                ready = [b for b, ok in browser_key_status(bpats).items() if ok]
+                if ready:
+                    _print(_OK, "Detecção no navegador", f"{svcs} — via {', '.join(ready)}")
+                else:
+                    _print(_WARN, "Detecção no navegador", f"{svcs} — nenhum navegador usou o mic ainda; entre numa call (ex.: Meet) uma vez")
+            else:
+                _print(_OK, "Detecção no navegador", "desligada (browsers = \"\")")
+        except Exception as e:
+            _print(_WARN, "Detecção no navegador", str(e))
+
+    # Áudio — enumeração WASAPI (pyaudiowpatch); fora do Windows a captura ainda
+    # não existe e o item é não-aplicável (#98)
+    if sys.platform != "win32":
+        _print(_OK, "Dispositivos de áudio", "captura não suportada neste SO ainda (Windows-only)")
+    else:
+        try:
+            import pyaudiowpatch as pyaudio
+
+            p = pyaudio.PyAudio()
+            try:
+                mic = p.get_default_input_device_info()["name"]
+                lb = p.get_default_wasapi_loopback()["name"]
+            finally:
+                p.terminate()
+            _print(_OK, "Microfone padrão", mic)
+            _print(_OK, "Loopback padrão", lb)
+        except Exception as e:
+            _print(_FAIL, "Dispositivos de áudio", str(e))
+            failures += 1
 
     # Compressão do áudio guardado (ffmpeg): WAV cru -> opus/flac. Sem ele os arquivos
     # ficam gigantes (~1,3 GB/h); também decodifica áudio comprimido numa re-transcrição.
@@ -482,14 +495,19 @@ def cmd_doctor(args) -> int:
         exe = util.ffmpeg_command()
         _print(_OK, "Compressão de áudio (ffmpeg)", f"no PATH: {exe[0] if exe else 'ffmpeg'}")
     elif lvl == "err":
-        _print(_FAIL, "Compressão de áudio (ffmpeg)",
-               f"AUSENTE no PATH do Windows — o áudio fica em WAV cru (~1,3 GB/h), não {fmt} (~20 MB/h). "
-               "Instale: winget install ffmpeg (entra no PATH do Windows sozinho — não é uma pasta do "
-               "ScribaDev), feche e reabra o app. Confira com: where ffmpeg")
+        if sys.platform == "win32":
+            hint = (f"AUSENTE no PATH do Windows — o áudio fica em WAV cru (~1,3 GB/h), não {fmt} (~20 MB/h). "
+                    "Instale: winget install ffmpeg (entra no PATH do Windows sozinho — não é uma pasta do "
+                    "ScribaDev), feche e reabra o app. Confira com: where ffmpeg")
+        else:
+            hint = (f"AUSENTE no PATH — o áudio fica em WAV cru (~1,3 GB/h), não {fmt} (~20 MB/h). "
+                    "Instale pelo gerenciador do SO (ex.: apt install ffmpeg / brew install ffmpeg) "
+                    "e confira com: which ffmpeg")
+        _print(_FAIL, "Compressão de áudio (ffmpeg)", hint)
         failures += 1
     else:
         _print(_WARN, "Compressão de áudio (ffmpeg)",
-               "ausente no PATH do Windows — necessário p/ compactar o áudio guardado e re-transcrever áudio comprimido")
+               "ausente no PATH — necessário p/ compactar o áudio guardado e re-transcrever áudio comprimido")
 
     # Diarização
     if cfg and cfg.diarization.enabled:

--- a/scriba/diagnostics.py
+++ b/scriba/diagnostics.py
@@ -88,14 +88,11 @@ def environment_report() -> str:
     """Resumo do ambiente (versão, Python, SO, GPU, diarização) — o que o suporte precisa."""
     from . import __version__, updates
 
-    gpu = "nao"
-    try:
-        import ctypes
+    # via camada de plataforma: ctypes.WinDLL nem existe fora do Windows e o
+    # except OSError antigo não pegaria o AttributeError no Linux/macOS (#98)
+    from . import plat
 
-        ctypes.WinDLL("nvcuda.dll")
-        gpu = "sim (NVIDIA)"
-    except OSError:
-        pass
+    gpu = "sim (NVIDIA)" if plat.has_nvidia_gpu() else "nao"
     try:
         import importlib.util as ilu
 

--- a/scriba/plat/__init__.py
+++ b/scriba/plat/__init__.py
@@ -20,4 +20,5 @@ else:
 
 app_data_dir = _backend.app_data_dir
 default_recordings_dir = _backend.default_recordings_dir
+has_nvidia_gpu = _backend.has_nvidia_gpu
 open_path = _backend.open_path

--- a/scriba/plat/_posix.py
+++ b/scriba/plat/_posix.py
@@ -29,6 +29,19 @@ def default_recordings_dir() -> Path:
     return app_data_dir() / "gravacoes"
 
 
+def has_nvidia_gpu() -> bool:
+    """Driver NVIDIA presente? Linux: libcuda.so.1 carrega; macOS: não existe CUDA."""
+    if sys.platform == "darwin":
+        return False
+    import ctypes
+
+    try:
+        ctypes.CDLL("libcuda.so.1")
+        return True
+    except OSError:
+        return False
+
+
 def open_path(path) -> None:
     """Abre arquivo ou pasta no gerenciador do SO (xdg-open no Linux, open no macOS)."""
     import subprocess

--- a/scriba/plat/_win.py
+++ b/scriba/plat/_win.py
@@ -20,6 +20,17 @@ def default_recordings_dir() -> Path:
     return Path(r"C:\temp\scribadev\gravacoes")
 
 
+def has_nvidia_gpu() -> bool:
+    """Driver NVIDIA presente? (nvcuda.dll carrega — sonda histórica do diagnóstico)."""
+    import ctypes
+
+    try:
+        ctypes.WinDLL("nvcuda.dll")
+        return True
+    except OSError:
+        return False
+
+
 def open_path(path) -> None:
     """Abre arquivo ou pasta no Explorer (substituto do os.startfile).
 

--- a/scriba/qt/settings_ui.py
+++ b/scriba/qt/settings_ui.py
@@ -696,13 +696,11 @@ class SettingsWindow(QWidget):
 
     @staticmethod
     def _gpu_str() -> str:
-        try:
-            import ctypes
+        from .. import plat
 
-            ctypes.WinDLL("nvcuda.dll")
+        if plat.has_nvidia_gpu():
             return "NVIDIA (CUDA disponível)"
-        except Exception:
-            return "sem GPU CUDA — usa CPU"
+        return "sem GPU CUDA — usa CPU"
 
     def _check_updates_about(self) -> None:
         self._about_update_btn.setVisible(False)

--- a/scriba/util.py
+++ b/scriba/util.py
@@ -187,6 +187,10 @@ def bootstrap_cuda_dlls() -> None:
     O ctranslate2 carrega cublas64_12.dll com LoadLibrary simples, que só
     consulta o PATH do processo — os.add_dll_directory sozinho não basta.
     """
+    if sys.platform != "win32":
+        # layout Lib/site-packages/nvidia/*/bin e os.add_dll_directory são do
+        # Windows; no Linux o CUDA chega pelos wheels (RPATH), no macOS não existe (#98)
+        return
     global _dll_dirs_added
     if _dll_dirs_added:
         return

--- a/tests/test_plat.py
+++ b/tests/test_plat.py
@@ -63,11 +63,26 @@ class TestBackendPosix(unittest.TestCase):
             )
 
 
+class TestHasNvidiaGpu(unittest.TestCase):
+    def test_win_devolve_bool(self):
+        # sonda real no runner (com ou sem GPU): o contrato é não levantar
+        self.assertIsInstance(_win.has_nvidia_gpu(), bool)
+
+    def test_posix_linux_devolve_bool(self):
+        with mock.patch.object(sys, "platform", "linux"):
+            self.assertIsInstance(_posix.has_nvidia_gpu(), bool)
+
+    def test_posix_macos_sempre_false(self):
+        with mock.patch.object(sys, "platform", "darwin"):
+            self.assertIs(_posix.has_nvidia_gpu(), False)
+
+
 class TestDespacho(unittest.TestCase):
     def test_backend_casa_com_o_so_atual(self):
         esperado = _win if sys.platform == "win32" else _posix
         self.assertIs(plat.app_data_dir, esperado.app_data_dir)
         self.assertIs(plat.default_recordings_dir, esperado.default_recordings_dir)
+        self.assertIs(plat.has_nvidia_gpu, esperado.has_nvidia_gpu)
         self.assertIs(plat.open_path, esperado.open_path)
 
     def test_util_app_dir_vem_da_camada(self):


### PR DESCRIPTION
Quarto degrau do epico #104 (paralela a #97, ja mergeada - rebase nao foi preciso, regioes distintas de util.py).

**O que muda**
- `plat.has_nvidia_gpu()`: sonda unica de GPU NVIDIA por SO - `_win` mantem o `nvcuda.dll` historico; `_posix` usa `libcuda.so.1` no Linux e `False` no macOS (sem CUDA). Elimina a duplicacao entre `diagnostics.environment_report` e `settings_ui._gpu_str` e corrige bug latente: o `except OSError` de diagnostics nao pegaria o `AttributeError` de `ctypes.WinDLL` no POSIX (o relatorio de ambiente quebraria).
- `util.bootstrap_cuda_dlls()`: early-return fora do win32.
- `cmd_doctor` platform-aware: no POSIX os checks Windows-only viram nao-aplicaveis em vez de `_FAIL` obrigatorio (era exit 1 garantido no Linux); hint de instalacao do ffmpeg por SO.

**Validacao**
- **Windows E2E**: `scribadev doctor` no venv real do app sai com **exit 0** e saida identica (todos os blocos Windows executam: imports nativos, deteccao Teams/Zoom/Webex/navegador, mic+loopback WASAPI, GPU CUDA 1 dispositivo, diarizacao GPU).
- Suite completa verde no Windows: **598 testes, OK** (3 novos p/ has_nvidia_gpu).
- Linux: exit 0 do doctor sera exercitado no Cowork (#99) e travado no CI Linux (#103).

Closes #98