### PR TITLE
Port multiplataforma: instancia unica + relaunch cross-platform (#100)

### DIFF
--- a/scriba/main.py
+++ b/scriba/main.py
@@ -10,7 +10,6 @@ A UI é PySide6 (scriba/qt/); qualquer thread agenda trabalho na GUI por self.ui
 
 from __future__ import annotations
 
-import ctypes
 import logging
 import logging.handlers
 import os
@@ -19,60 +18,16 @@ import sys
 import threading
 import time
 
-from . import util
+from . import plat, util
 from .config import load
 from .detector import Detector
 from .recorder import Recording
 
 log = logging.getLogger("scriba")
 
-_mutex_handle = None  # mantém o handle vivo durante o processo
-
-
-_MUTEX_NAME = "Local\\ScribaDevSingleInstance"
-
-
-def _single_instance(retries: int = 0, delay: float = 0.4, name: str = _MUTEX_NAME) -> bool:
-    """True se esta é a única instância (adquiriu o mutex nomeado `name`).
-
-    Se o mutex já existe e `retries` > 0, FECHA o handle e tenta de novo após `delay` s
-    até `retries` vezes. Isso conserta o reinício pós-update intermitente (#74): o
-    relançamento pode chegar enquanto a instância ANTERIOR ainda está no teardown
-    (encerra por `os._exit` em até 3 s) segurando o mutex — sem o retry a nova instância
-    via ERROR_ALREADY_EXISTS e abortava calada, então o app "não reabria sozinho".
-
-    Importante: quando o mutex já existe, CreateMutexW devolve um handle para o mutex
-    EXISTENTE; segurá-lo manteria o objeto vivo e o retry nunca veria a liberação — por
-    isso fechamos o handle antes de reesperar."""
-    global _mutex_handle
-    k32 = ctypes.windll.kernel32
-    for attempt in range(retries + 1):
-        _mutex_handle = k32.CreateMutexW(None, False, name)
-        if k32.GetLastError() != 183:  # != ERROR_ALREADY_EXISTS → adquirimos
-            return True
-        if _mutex_handle:
-            k32.CloseHandle(_mutex_handle)
-            _mutex_handle = None
-        if attempt < retries:
-            time.sleep(delay)
-    return False
-
-
-# Evento nomeado que a 2ª instância usa para pedir "mostre a janela" à 1ª —
-# sem isso, clicar no atalho com o app já na bandeja não fazia nada visível.
-_SHOW_EVENT_NAME = "Local\\ScribaDevShowWindow"
-
-
-def _signal_show_window() -> bool:
-    """Acorda a instância que já está rodando (True se conseguiu sinalizar)."""
-    EVENT_MODIFY_STATE = 0x0002
-    k32 = ctypes.windll.kernel32
-    handle = k32.OpenEventW(EVENT_MODIFY_STATE, False, _SHOW_EVENT_NAME)
-    if not handle:
-        return False
-    k32.SetEvent(handle)
-    k32.CloseHandle(handle)
-    return True
+# Instância única + sinal "mostre a janela" + relaunch: por SO, na camada de
+# plataforma (plat._win = mutex/evento/PowerShell históricos; plat._posix =
+# flock/socket/Popen). O retry pós-update (#74) vive lá.
 
 
 def _setup_logging() -> None:
@@ -546,34 +501,13 @@ class ScribaApp:
         gracioso travar. Sem o 'forçar', um cleanup preso (tray/thread) segura o mutex,
         a nova instância aborta no single-instance e o app 'não reinicia sozinho'.
         Auto-restart do update (#19)."""
-        import subprocess
-        from pathlib import Path
-
         from PySide6.QtWidgets import QMessageBox
 
-        pyw = Path(sys.executable)
-        if pyw.name.lower() == "python.exe":
-            pyw = pyw.with_name("pythonw.exe")  # sem janela de console
-        # PS que espera este processo sair (libera o mutex) e sobe a nova instância.
-        # Marca SCRIBA_RELAUNCHED p/ a nova instância dar retry no single-instance (#74),
-        # e LOGA cada passo — antes a falha do Start-Process era 100% silenciosa.
-        ps = ("$ErrorActionPreference='Continue'; "
-              f"Write-Output ('[' + (Get-Date -Format s) + '] relaunch: aguardando pid {os.getpid()} sair'); "
-              f"Wait-Process -Id {os.getpid()} -Timeout 60 -ErrorAction SilentlyContinue; "
-              "$env:SCRIBA_RELAUNCHED='1'; "
-              "Write-Output 'relaunch: subindo nova instancia'; "
-              f"try {{ Start-Process '{pyw}' -ArgumentList '-m','scriba.cli','run' -ErrorAction Stop; "
-              "Write-Output 'relaunch: Start-Process OK' } "
-              "catch { Write-Output ('relaunch: Start-Process FALHOU - ' + $_.Exception.Message) }")
+        # o COMO relançar é por SO (plat._win = PowerShell Wait-Process/Start-Process;
+        # plat._posix = Popen detached + retry no lock); o fluxo de UX fica aqui
         try:
             util.ensure_app_dirs()
-            logf = open(util.LOGS_DIR / "relaunch.log", "a", encoding="utf-8")
-            subprocess.Popen(
-                ["powershell", "-NoProfile", "-WindowStyle", "Hidden", "-Command", ps],
-                stdout=logf, stderr=subprocess.STDOUT,
-                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0)
-                | getattr(subprocess, "DETACHED_PROCESS", 0),
-            )
+            plat.spawn_relaunch(os.getpid(), util.LOGS_DIR / "relaunch.log")
             scheduled = True
         except Exception:
             log.exception("falha ao agendar o relançamento")
@@ -980,15 +914,12 @@ class ScribaApp:
 
     def _show_window_listener(self) -> None:
         """Espera o sinal de uma 2ª instância (atalho clicado) e mostra a janela."""
-        handle = ctypes.windll.kernel32.CreateEventW(None, False, False, _SHOW_EVENT_NAME)
-        if not handle:
-            log.warning("não consegui criar o evento de ativação")
-            return
-        while not self.stop_event.is_set():
-            # timeout de 1 s para reavaliar o stop_event; 0 = WAIT_OBJECT_0 (sinalizado)
-            if ctypes.windll.kernel32.WaitForSingleObject(handle, 1000) == 0:
-                log.info("ativado por uma 2ª instância (atalho) — mostrando a janela")
-                self.show_main()
+
+        def on_signal() -> None:
+            log.info("ativado por uma 2ª instância (atalho) — mostrando a janela")
+            self.show_main()
+
+        plat.show_window_listener(self.stop_event, on_signal)
 
     # ----------------------------------------------------------------- run --
 
@@ -1112,10 +1043,10 @@ def run_app(minimized: bool = False) -> int:
     # o mutex; damos alguns retries p/ ela liberar (o 2º-launch normal, do atalho, segue
     # instantâneo — sem retry). Marcado pela env var setada no PS do relaunch.
     relaunched = os.environ.get("SCRIBA_RELAUNCHED") == "1"
-    if not _single_instance(retries=10 if relaunched else 0):
+    if not plat.single_instance(retries=10 if relaunched else 0):
         # clique no atalho com o app já vivo: pede à instância ativa que abra a
         # janela principal (antes a 2ª instância morria muda e "nada acontecia")
-        if _signal_show_window():
+        if plat.signal_show_window():
             print("ScribaDev já está rodando — abrindo a janela da instância ativa.")
         else:
             print("ScribaDev já está rodando (ícone na bandeja).")

--- a/scriba/plat/__init__.py
+++ b/scriba/plat/__init__.py
@@ -22,3 +22,9 @@ app_data_dir = _backend.app_data_dir
 default_recordings_dir = _backend.default_recordings_dir
 has_nvidia_gpu = _backend.has_nvidia_gpu
 open_path = _backend.open_path
+
+# instância única + relaunch pós-update (#100)
+single_instance = _backend.single_instance
+signal_show_window = _backend.signal_show_window
+show_window_listener = _backend.show_window_listener
+spawn_relaunch = _backend.spawn_relaunch

--- a/scriba/plat/_posix.py
+++ b/scriba/plat/_posix.py
@@ -6,9 +6,12 @@ este módulo se divide em _linux.py/_mac.py; por ora os ramos por SO cabem aqui.
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from pathlib import Path
+
+log = logging.getLogger("scriba.plat")
 
 
 def app_data_dir() -> Path:
@@ -48,3 +51,111 @@ def open_path(path) -> None:
 
     opener = "open" if sys.platform == "darwin" else "xdg-open"
     subprocess.Popen([opener, str(path)])
+
+
+# ------------------------------------------------- instância única (#100) ---
+# Análogo POSIX do mutex nomeado do Windows: flock num lockfile. O flock morre
+# junto com o processo (inclusive via os._exit), então o retry pós-update (#74)
+# funciona igual: a nova instância espera a antiga sair e adquire o lock.
+
+_lock_file = None  # mantém o arquivo (e o flock) vivos durante o processo
+
+
+def _lock_path() -> Path:
+    return app_data_dir() / "instance.lock"
+
+
+def _sock_path() -> Path:
+    return app_data_dir() / "show.sock"
+
+
+def single_instance(retries: int = 0, delay: float = 0.4, name: str | None = None) -> bool:
+    """True se esta é a única instância (adquiriu o flock do lockfile).
+
+    `name` sobrepõe o caminho do lockfile (testes). Mesmo contrato do backend
+    Windows: com `retries` > 0, fecha e reespera `delay` s a cada tentativa.
+    """
+    import fcntl
+    import time
+
+    global _lock_file
+    path = Path(name) if name else _lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for attempt in range(retries + 1):
+        f = open(path, "w", encoding="utf-8")
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            f.write(str(os.getpid()))
+            f.flush()
+            _lock_file = f
+            return True
+        except OSError:
+            f.close()
+            if attempt < retries:
+                time.sleep(delay)
+    return False
+
+
+def signal_show_window() -> bool:
+    """Acorda a instância que já está rodando (True se conseguiu sinalizar)."""
+    import socket
+
+    s = socket.socket(socket.AF_UNIX)
+    try:
+        s.connect(str(_sock_path()))
+        return True
+    except OSError:
+        return False
+    finally:
+        s.close()
+
+
+def show_window_listener(stop_event, on_signal) -> None:
+    """Loop (para uma daemon-thread): espera o sinal de uma 2ª instância e chama on_signal."""
+    import socket
+
+    sp = _sock_path()
+    try:
+        sp.unlink(missing_ok=True)  # sock órfão de um crash: só o dono do lock escuta
+        srv = socket.socket(socket.AF_UNIX)
+        srv.bind(str(sp))
+        srv.listen(1)
+        srv.settimeout(1.0)  # reavalia o stop_event a cada 1 s (igual ao backend win)
+    except OSError:
+        log.warning("não consegui criar o socket de ativação em %s", sp)
+        return
+    with srv:
+        while not stop_event.is_set():
+            try:
+                conn, _ = srv.accept()
+                conn.close()
+                on_signal()
+            except TimeoutError:
+                continue
+            except OSError:
+                return
+
+
+def spawn_relaunch(pid: int, log_path) -> None:
+    """Sobe uma nova instância detached; ela espera esta sair via retry no lock.
+
+    Diferente do Windows (que precisa do PowerShell Wait-Process), aqui não há
+    intermediário: o flock solta sozinho quando este processo morre, e a nova
+    instância (SCRIBA_RELAUNCHED=1) dá retry no single_instance até adquirir.
+    Não usa os.execv de propósito: execv substituiria o processo NA HORA,
+    abandonando o teardown gracioso do Qt (uma gravação sendo salva na saída
+    seria cortada). Exceções propagam: o chamador decide como avisar.
+    """
+    import subprocess
+    import time
+
+    env = dict(os.environ, SCRIBA_RELAUNCHED="1")
+    logf = open(log_path, "a", encoding="utf-8")
+    logf.write(f"[{time.strftime('%Y-%m-%dT%H:%M:%S')}] relaunch: subindo nova instancia (aguarda pid {pid} soltar o lock)\n")
+    logf.flush()
+    subprocess.Popen(
+        [sys.executable, "-m", "scriba.cli", "run"],
+        stdout=logf, stderr=subprocess.STDOUT,
+        start_new_session=True,  # sobrevive à morte deste processo (setsid)
+        env=env,
+    )

--- a/scriba/plat/_win.py
+++ b/scriba/plat/_win.py
@@ -1,13 +1,18 @@
 """Backend Windows da camada de plataforma — comportamento idêntico ao histórico.
 
-Código MOVIDO de util.py/config.py (não reescrito): qualquer mudança aqui é
-mudança de comportamento no Windows e precisa de justificativa própria (#104).
+Código MOVIDO de util.py/config.py/main.py (não reescrito): qualquer mudança
+aqui é mudança de comportamento no Windows e precisa de justificativa própria (#104).
 """
 
 from __future__ import annotations
 
+import logging
 import os
+import sys
+import time
 from pathlib import Path
+
+log = logging.getLogger("scriba.plat")
 
 
 def app_data_dir() -> Path:
@@ -41,3 +46,102 @@ def open_path(path) -> None:
     import subprocess
 
     subprocess.Popen(["explorer.exe", str(path)])
+
+
+# ------------------------------------------------- instância única (#100) ---
+# Código MOVIDO de main.py sem reescrita: a lógica de retry pós-update (#74)
+# é delicada — a nova instância espera a antiga liberar o mutex no teardown.
+
+_mutex_handle = None  # mantém o handle vivo durante o processo
+
+_MUTEX_NAME = "Local\\ScribaDevSingleInstance"
+
+# Evento nomeado que a 2ª instância usa para pedir "mostre a janela" à 1ª —
+# sem isso, clicar no atalho com o app já na bandeja não fazia nada visível.
+_SHOW_EVENT_NAME = "Local\\ScribaDevShowWindow"
+
+
+def single_instance(retries: int = 0, delay: float = 0.4, name: str = _MUTEX_NAME) -> bool:
+    """True se esta é a única instância (adquiriu o mutex nomeado `name`).
+
+    Se o mutex já existe e `retries` > 0, FECHA o handle e tenta de novo após `delay` s
+    até `retries` vezes. Isso conserta o reinício pós-update intermitente (#74): o
+    relançamento pode chegar enquanto a instância ANTERIOR ainda está no teardown
+    (encerra por `os._exit` em até 3 s) segurando o mutex — sem o retry a nova instância
+    via ERROR_ALREADY_EXISTS e abortava calada, então o app "não reabria sozinho".
+
+    Importante: quando o mutex já existe, CreateMutexW devolve um handle para o mutex
+    EXISTENTE; segurá-lo manteria o objeto vivo e o retry nunca veria a liberação — por
+    isso fechamos o handle antes de reesperar."""
+    import ctypes
+
+    global _mutex_handle
+    k32 = ctypes.windll.kernel32
+    for attempt in range(retries + 1):
+        _mutex_handle = k32.CreateMutexW(None, False, name)
+        if k32.GetLastError() != 183:  # != ERROR_ALREADY_EXISTS → adquirimos
+            return True
+        if _mutex_handle:
+            k32.CloseHandle(_mutex_handle)
+            _mutex_handle = None
+        if attempt < retries:
+            time.sleep(delay)
+    return False
+
+
+def signal_show_window() -> bool:
+    """Acorda a instância que já está rodando (True se conseguiu sinalizar)."""
+    import ctypes
+
+    EVENT_MODIFY_STATE = 0x0002
+    k32 = ctypes.windll.kernel32
+    handle = k32.OpenEventW(EVENT_MODIFY_STATE, False, _SHOW_EVENT_NAME)
+    if not handle:
+        return False
+    k32.SetEvent(handle)
+    k32.CloseHandle(handle)
+    return True
+
+
+def show_window_listener(stop_event, on_signal) -> None:
+    """Loop (para uma daemon-thread): espera o sinal de uma 2ª instância e chama on_signal."""
+    import ctypes
+
+    handle = ctypes.windll.kernel32.CreateEventW(None, False, False, _SHOW_EVENT_NAME)
+    if not handle:
+        log.warning("não consegui criar o evento de ativação")
+        return
+    while not stop_event.is_set():
+        # timeout de 1 s para reavaliar o stop_event; 0 = WAIT_OBJECT_0 (sinalizado)
+        if ctypes.windll.kernel32.WaitForSingleObject(handle, 1000) == 0:
+            on_signal()
+
+
+def spawn_relaunch(pid: int, log_path) -> None:
+    """Agenda uma nova instância para DEPOIS que `pid` sair (libera o mutex).
+
+    PS que espera este processo sair e sobe a nova instância. Marca
+    SCRIBA_RELAUNCHED p/ a nova instância dar retry no single-instance (#74),
+    e LOGA cada passo — antes a falha do Start-Process era 100% silenciosa.
+    Exceções propagam: o chamador decide como avisar o usuário.
+    """
+    import subprocess
+
+    pyw = Path(sys.executable)
+    if pyw.name.lower() == "python.exe":
+        pyw = pyw.with_name("pythonw.exe")  # sem janela de console
+    ps = ("$ErrorActionPreference='Continue'; "
+          f"Write-Output ('[' + (Get-Date -Format s) + '] relaunch: aguardando pid {pid} sair'); "
+          f"Wait-Process -Id {pid} -Timeout 60 -ErrorAction SilentlyContinue; "
+          "$env:SCRIBA_RELAUNCHED='1'; "
+          "Write-Output 'relaunch: subindo nova instancia'; "
+          f"try {{ Start-Process '{pyw}' -ArgumentList '-m','scriba.cli','run' -ErrorAction Stop; "
+          "Write-Output 'relaunch: Start-Process OK' } "
+          "catch { Write-Output ('relaunch: Start-Process FALHOU - ' + $_.Exception.Message) }")
+    logf = open(log_path, "a", encoding="utf-8")
+    subprocess.Popen(
+        ["powershell", "-NoProfile", "-WindowStyle", "Hidden", "-Command", ps],
+        stdout=logf, stderr=subprocess.STDOUT,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        | getattr(subprocess, "DETACHED_PROCESS", 0),
+    )

--- a/tests/test_relaunch.py
+++ b/tests/test_relaunch.py
@@ -8,6 +8,7 @@ Nada real roda aqui: subprocess, QMessageBox, os._exit e threading.Timer são st
 então o teste não abre janela (o QMessageBox é modal), não relança processo nem encerra o runner.
 """
 
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -18,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from scriba.main import ScribaApp  # noqa: E402
 
 
+@unittest.skipUnless(sys.platform == "win32", "asserta o relançador PowerShell (plat._win)")
 class RelaunchTests(unittest.TestCase):
     def _app(self):
         # __new__ sem __init__: não cria Tk root nem threads; só queremos o método
@@ -81,48 +83,107 @@ class RelaunchTests(unittest.TestCase):
 
 @unittest.skipUnless(sys.platform == "win32", "mutex nomeado é específico do Windows")
 class SingleInstanceRetryTests(unittest.TestCase):
-    """_single_instance com retry: conserta o reinício pós-update intermitente (#74) —
-    a nova instância espera a antiga liberar o mutex em vez de abortar de cara."""
+    """single_instance (plat._win) com retry: conserta o reinício pós-update
+    intermitente (#74) — a nova instância espera a antiga liberar o mutex em vez
+    de abortar de cara. Código movido de main.py para a camada na #100."""
 
     def setUp(self):
         import ctypes
         import os
-        from scriba import main
-        self.main = main
+        from scriba.plat import _win
+        self.win = _win
         self.k32 = ctypes.windll.kernel32
         # nome ÚNICO por processo: não colide com o mutex do app real que pode estar vivo
         self.name = f"Local\\ScribaDevTest_{os.getpid()}"
-        main._mutex_handle = None
+        _win._mutex_handle = None
 
     def tearDown(self):
-        if self.main._mutex_handle:
-            self.k32.CloseHandle(self.main._mutex_handle)
-            self.main._mutex_handle = None
+        if self.win._mutex_handle:
+            self.k32.CloseHandle(self.win._mutex_handle)
+            self.win._mutex_handle = None
 
     def test_sem_retry_falha_de_cara_com_mutex_preso(self):
         held = self.k32.CreateMutexW(None, False, self.name)  # simula instância anterior
         try:
-            self.assertFalse(self.main._single_instance(retries=0, name=self.name))
+            self.assertFalse(self.win.single_instance(retries=0, name=self.name))
         finally:
             self.k32.CloseHandle(held)
 
     def test_retry_espera_mas_falha_se_nunca_libera(self):
         held = self.k32.CreateMutexW(None, False, self.name)
         try:
-            self.assertFalse(self.main._single_instance(retries=3, delay=0.01, name=self.name))
+            self.assertFalse(self.win.single_instance(retries=3, delay=0.01, name=self.name))
         finally:
             self.k32.CloseHandle(held)
 
     def test_adquire_quando_livre(self):
-        self.assertTrue(self.main._single_instance(retries=2, delay=0.01, name=self.name))
-        self.assertIsNotNone(self.main._mutex_handle)  # segura o handle no sucesso
+        self.assertTrue(self.win.single_instance(retries=2, delay=0.01, name=self.name))
+        self.assertIsNotNone(self.win._mutex_handle)  # segura o handle no sucesso
 
     def test_retry_adquire_apos_liberacao(self):
         # a instância anterior segura o mutex e o solta durante os retries → adquire
         import threading
         held = self.k32.CreateMutexW(None, False, self.name)
         threading.Timer(0.05, lambda: self.k32.CloseHandle(held)).start()
-        self.assertTrue(self.main._single_instance(retries=30, delay=0.02, name=self.name))
+        self.assertTrue(self.win.single_instance(retries=30, delay=0.02, name=self.name))
+
+
+class PosixSpawnRelaunchTests(unittest.TestCase):
+    """spawn_relaunch POSIX (mockado — roda em qualquer SO): Popen detached com
+    SCRIBA_RELAUNCHED=1; a espera pela instância antiga é o retry no flock."""
+
+    def test_popen_detached_com_env_de_relaunch(self):
+        from scriba.plat import _posix
+
+        with mock.patch("subprocess.Popen") as popen, \
+                mock.patch("builtins.open", mock.mock_open()):
+            _posix.spawn_relaunch(1234, Path("relaunch.log"))
+
+        argv = popen.call_args[0][0]
+        self.assertEqual(argv, [sys.executable, "-m", "scriba.cli", "run"])
+        kwargs = popen.call_args.kwargs
+        self.assertTrue(kwargs["start_new_session"])  # sobrevive à morte do pai
+        self.assertEqual(kwargs["env"]["SCRIBA_RELAUNCHED"], "1")  # retry no lock (#74)
+
+
+@unittest.skipUnless(os.name == "posix", "flock/AF_UNIX são POSIX")
+class PosixSingleInstanceTests(unittest.TestCase):
+    """flock real: mesmo contrato do mutex do Windows (roda no CI Linux, #103)."""
+
+    def setUp(self):
+        import tempfile
+        from scriba.plat import _posix
+        self.posix = _posix
+        self.tmp = tempfile.TemporaryDirectory()
+        self.lock = str(Path(self.tmp.name) / "instance.lock")
+        _posix._lock_file = None
+
+    def tearDown(self):
+        if self.posix._lock_file:
+            self.posix._lock_file.close()
+            self.posix._lock_file = None
+        self.tmp.cleanup()
+
+    def test_adquire_quando_livre(self):
+        self.assertTrue(self.posix.single_instance(name=self.lock))
+        self.assertIsNotNone(self.posix._lock_file)
+
+    def test_segunda_instancia_falha_com_lock_preso(self):
+        import fcntl
+        held = open(self.lock, "w")
+        fcntl.flock(held, fcntl.LOCK_EX | fcntl.LOCK_NB)  # simula instância anterior
+        try:
+            self.assertFalse(self.posix.single_instance(retries=0, name=self.lock))
+        finally:
+            held.close()
+
+    def test_retry_adquire_apos_liberacao(self):
+        import fcntl
+        import threading
+        held = open(self.lock, "w")
+        fcntl.flock(held, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        threading.Timer(0.05, held.close).start()  # fechar o fd solta o flock
+        self.assertTrue(self.posix.single_instance(retries=30, delay=0.02, name=self.lock))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sexto degrau do epico #104 - a costura mais delicada (retry pos-update #74).

**O que muda**
- **Windows: codigo MOVIDO, nao reescrito.** Mutex nomeado (`Local\ScribaDevSingleInstance`), evento show-window e o relancador PowerShell (Wait-Process/Start-Process) saem de `main.py` para `plat/_win.py` byte a byte na logica - incluindo o retry pos-update da #74 (fechar handle antes de reesperar).
- **POSIX (novo em `plat/_posix.py`)**: `flock` em `instance.lock` (o lock morre com o processo, inclusive `os._exit` - mesmo contrato do mutex), socket Unix `show.sock` para o raise-window, e `spawn_relaunch` com `Popen(start_new_session=True)` + `SCRIBA_RELAUNCHED=1` (a nova instancia espera a antiga via retry no lock - nao precisa do intermediario que o Windows precisa).
- **Nota de design**: nao usei `os.execv` (que a spec sugeria) de proposito - execv substitui o processo NA HORA, abandonando o teardown gracioso do Qt (uma gravacao sendo salva na saida seria cortada). O Popen detached + retry reproduz fielmente o fluxo do Windows.
- `main.py` mantem so a orquestracao de UX (dialogo, request_quit, watchdog de 3 s).

**Validacao**
- **E2E no Windows**: com o app real vivo (instancia de ontem, codigo antigo), uma 2a instancia com o codigo novo detectou o mutex e sinalizou a janela: 'ScribaDev ja esta rodando - abrindo a janela da instancia ativa', exit 0. Compatibilidade cruzada de versoes confirmada (mesmos nomes de mutex/evento).
- Testes do mutex migrados para `plat._win` (mesmos 4 cenarios de retry da #74); novos testes POSIX: `spawn_relaunch` mockado (roda em qualquer SO) e flock real (roda no CI Linux, #103).
- Suite completa verde no Windows: **605 testes, OK**.

Closes #100