### PR TITLE
Port multiplataforma: notificacoes via camada (toasts win / no-op POSIX) (#101)

### DIFF
--- a/scriba/cli.py
+++ b/scriba/cli.py
@@ -554,7 +554,10 @@ def cmd_doctor(args) -> int:
             from .notify import Notifier
 
             Notifier().test()
-            _print(_OK, "Toast", "notificação de teste disparada")
+            if sys.platform == "win32":
+                _print(_OK, "Toast", "notificação de teste disparada")
+            else:
+                _print(_OK, "Toast", "no-op neste SO (toasts nativos ainda não suportados) — logado")
         except Exception as e:
             _print(_FAIL, "Toast", str(e))
             failures += 1

--- a/scriba/notify.py
+++ b/scriba/notify.py
@@ -1,10 +1,15 @@
-"""Notificações toast do Windows (com botão "Abrir notas")."""
+"""Notificações do app: toasts nativos no Windows (com botão "Abrir notas");
+no-op logado no POSIX até os marcos de notificação nativa do épico #104 (#101)."""
 
 from __future__ import annotations
 
+import logging
+import sys
 from pathlib import Path
 
 from . import util
+
+log = logging.getLogger("scriba.notify")
 
 AUMID = util.APP_AUMID
 _DISPLAY = "ScribaDev"
@@ -24,7 +29,7 @@ def _register_aumid() -> None:
             winreg.SetValueEx(k, "IconUri", 0, winreg.REG_SZ, str(util.ICON_PNG))
 
 
-class Notifier:
+class _WindowsNotifier:
     def __init__(self):
         from . import util
 
@@ -63,3 +68,23 @@ class Notifier:
         from . import util
 
         self._toast(["ScribaDev", "Notificação de teste — clique para abrir a pasta do app"], open_path=util.APP_DIR)
+
+
+class _NoopNotifier:
+    """POSIX (Marco 1 do #104): notificações nativas ainda não existem — loga e segue.
+
+    Mesma interface do notifier do Windows; os marcos seguintes trocam por
+    notify-send (Linux) / UNUserNotification (macOS)."""
+
+    def info(self, title: str, body: str = "") -> None:
+        log.info("notificação (no-op neste SO): %s — %s", title, body)
+
+    def notes_ready(self, md_path: Path) -> None:
+        log.info("notificação (no-op neste SO): notas prontas — %s", md_path)
+
+    def test(self) -> None:
+        log.info("notificação de teste: toasts nativos não suportados neste SO ainda")
+
+
+# a classe pública escolhe o backend pelo SO (mesmo padrão da camada plat; #101)
+Notifier = _WindowsNotifier if sys.platform == "win32" else _NoopNotifier

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,36 @@
+"""#101: notificações por SO — toasts no Windows, no-op logado no POSIX."""
+
+import sys
+import unittest
+from pathlib import Path
+
+from scriba import notify
+
+
+class TestSelecaoPorSO(unittest.TestCase):
+    def test_notifier_do_so_atual(self):
+        esperado = notify._WindowsNotifier if sys.platform == "win32" else notify._NoopNotifier
+        self.assertIs(notify.Notifier, esperado)
+
+
+class TestNoopNotifier(unittest.TestCase):
+    """O no-op roda em qualquer SO (não toca windows_toasts) e nunca levanta."""
+
+    def setUp(self):
+        self.n = notify._NoopNotifier()
+
+    def test_info_nao_levanta(self):
+        with self.assertLogs("scriba.notify", level="INFO"):
+            self.n.info("Título", "corpo")
+
+    def test_notes_ready_nao_levanta(self):
+        with self.assertLogs("scriba.notify", level="INFO"):
+            self.n.notes_ready(Path("nota.md"))
+
+    def test_test_nao_levanta(self):
+        with self.assertLogs("scriba.notify", level="INFO"):
+            self.n.test()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Setimo degrau do epico #104.

**O que muda**
- `notify.Notifier` vira selecao por SO: `_WindowsNotifier` (o codigo de hoje, intacto: toasts WinRT + registro de AUMID) no win32; `_NoopNotifier` (loga e segue, mesma interface) no POSIX. Marcos futuros trocam o no-op por notify-send (Linux) / UNUserNotification (macOS).
- **Nota de design**: `notify.py` NAO foi movido para `scriba/plat/` - ele consome `util.*` em tudo (AUMID, icones, open_path) e `plat` nao pode importar `util` (ciclo: util importa plat). A selecao por SO dentro do proprio modulo cumpre o papel da camada sem criar o ciclo.
- `doctor --toast`: mensagem correta no POSIX ('no-op neste SO - logado').

**Validacao**
- **E2E no Windows (venv real)**: `scribadev doctor --toast` disparou o toast nativo real, saida identica.
- `tests/test_notify.py`: selecao por SO + no-op nunca levanta e loga (roda em qualquer SO).
- Suite completa verde no Windows: 605 testes, OK.
- Linux: `doctor --toast` sem excecao sera travado no CI Linux (#103).

Closes #101