### PR TITLE
Port multiplataforma: stubs POSIX das costuras de SO (#102)

### DIFF
--- a/scriba/autostart.py
+++ b/scriba/autostart.py
@@ -15,10 +15,16 @@ def _startup_dir() -> Path:
 
 
 def is_enabled() -> bool:
+    if sys.platform != "win32":
+        return False
     return (_startup_dir() / _LNK_NAME).exists()
 
 
 def set_autostart(enable: bool) -> int:
+    if sys.platform != "win32":
+        # pasta Startup/.lnk são do Windows; .desktop/LaunchAgent vêm em marcos futuros (#104)
+        print("autostart não suportado neste SO ainda (Windows-only por ora)")
+        return 1
     lnk = _startup_dir() / _LNK_NAME
     if not enable:
         lnk.unlink(missing_ok=True)

--- a/scriba/detector.py
+++ b/scriba/detector.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 import time
 from enum import Enum
 from typing import Callable
@@ -571,6 +572,11 @@ class Detector:
 
     def run(self, stop_event) -> None:
         """Loop de detecção (roda em thread própria)."""
+        if sys.platform != "win32":
+            # o ConsentStore do registro não tem equivalente POSIX; a detecção
+            # automática fora do Windows é um marco futuro (#104)
+            log.info("detecção automática de calls não suportada neste SO ainda — use a gravação manual")
+            return
         while not stop_event.is_set():
             try:
                 self.poll_once()
@@ -591,6 +597,9 @@ class Detector:
 
 def debug_loop() -> int:
     """`scriba detect`: imprime as transições de estado para teste manual."""
+    if sys.platform != "win32":
+        print("detecção automática de calls não suportada neste SO ainda (Windows-only por ora)")
+        return 1
     from .config import load
 
     # espelha os logs INFO/WARN do detector (GRACE, resume com o gap medido,

--- a/scriba/hotkey.py
+++ b/scriba/hotkey.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ctypes
 import logging
+import sys
 import threading
 from ctypes import wintypes
 from typing import Callable
@@ -50,6 +51,10 @@ class GlobalHotkey:
         self._thread: threading.Thread | None = None
 
     def start(self) -> bool:
+        if sys.platform != "win32":
+            # RegisterHotKey é Win32; atalho global POSIX vem em marcos futuros (#104)
+            log.info("hotkey global não suportada neste SO ainda — '%s' ignorado", self.spec)
+            return False
         parsed = parse(self.spec)
         if parsed is None:
             return False

--- a/scriba/recorder.py
+++ b/scriba/recorder.py
@@ -6,6 +6,7 @@ import json
 import logging
 import queue
 import struct
+import sys
 import threading
 import time
 from datetime import datetime
@@ -15,6 +16,10 @@ from . import util
 from .config import Config
 
 log = logging.getLogger("scriba.recorder")
+
+# captura ao vivo = WASAPI loopback (pyaudiowpatch), Windows-only por ora; a
+# captura POSIX (PipeWire/PulseAudio, CoreAudio) vem em marcos futuros (#104)
+_CAPTURE_UNSUPPORTED_MSG = "captura de áudio ao vivo não suportada neste SO ainda (Windows-only por ora)"
 
 _HEADER_PATCH_INTERVAL = 5.0  # s
 _SILENCE_THRESHOLD = 0.5  # s atrás do relógio antes de injetar silêncio
@@ -287,6 +292,10 @@ class Recording:
     """Uma gravação de reunião: mic + loopback numa pasta com meta.json."""
 
     def __init__(self, cfg: Config):
+        if sys.platform != "win32":
+            # protege também o caminho da GUI (start_recording): erro claro em
+            # vez de ModuleNotFoundError de pyaudiowpatch
+            raise RuntimeError(_CAPTURE_UNSUPPORTED_MSG)
         import pyaudiowpatch as pyaudio
 
         util.ensure_app_dirs()
@@ -454,6 +463,9 @@ def repair_folder(folder: Path) -> float:
 
 def record_for(seconds: int, show_ui: bool = True) -> int:
     """`scriba record N`: gravação manual (com a pílula flutuante, se habilitada)."""
+    if sys.platform != "win32":
+        print(_CAPTURE_UNSUPPORTED_MSG)
+        return 1
     from .config import load
 
     cfg = load()
@@ -489,6 +501,9 @@ def record_for(seconds: int, show_ui: bool = True) -> int:
 
 def list_devices() -> int:
     """`scriba devices`: lista mics e loopbacks WASAPI."""
+    if sys.platform != "win32":
+        print(_CAPTURE_UNSUPPORTED_MSG)
+        return 1
     import pyaudiowpatch as pyaudio
 
     pa = pyaudio.PyAudio()

--- a/scriba/shortcuts.py
+++ b/scriba/shortcuts.py
@@ -140,6 +140,10 @@ _FOLDERID_PROGRAMS = "A77F5D77-2E2B-44C3-A6A2-ABA601054A51"
 
 def create_shortcuts(desktop: bool = True, start_menu: bool = True) -> int:
     """Cria os atalhos pedidos. Retorna 0 se ao menos um foi criado."""
+    if sys.platform != "win32":
+        # .lnk/COM/AUMID são do Windows; .desktop/aliases vêm em marcos futuros (#104)
+        print("atalhos não suportados neste SO ainda (Windows-only por ora)")
+        return 1
     target = tray_exe()
     if not target.exists():
         print(f"não encontrei {target} — rode o setup.ps1 de novo")

--- a/scriba/wintitles.py
+++ b/scriba/wintitles.py
@@ -7,57 +7,63 @@ navegador (a aba ativa) que diz SE aquilo é uma reunião (Meet, Teams web...).
 
 from __future__ import annotations
 
-import ctypes
-from ctypes import wintypes
+import sys
 
-_user32 = ctypes.windll.user32
-_kernel32 = ctypes.windll.kernel32
+if sys.platform == "win32":
+    import ctypes
+    from ctypes import wintypes
 
-_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    _user32 = ctypes.windll.user32
+    _kernel32 = ctypes.windll.kernel32
 
+    _PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
 
-def _exe_of_pid(pid: int) -> str:
-    """Basename minúsculo do executável do processo ('' se inacessível)."""
-    handle = _kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
-    if not handle:
-        return ""
-    try:
-        buf = ctypes.create_unicode_buffer(1024)
-        size = wintypes.DWORD(len(buf))
-        if not _kernel32.QueryFullProcessImageNameW(handle, 0, buf, ctypes.byref(size)):
+    def _exe_of_pid(pid: int) -> str:
+        """Basename minúsculo do executável do processo ('' se inacessível)."""
+        handle = _kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
             return ""
-        return buf.value.rsplit("\\", 1)[-1].lower()
-    finally:
-        _kernel32.CloseHandle(handle)
+        try:
+            buf = ctypes.create_unicode_buffer(1024)
+            size = wintypes.DWORD(len(buf))
+            if not _kernel32.QueryFullProcessImageNameW(handle, 0, buf, ctypes.byref(size)):
+                return ""
+            return buf.value.rsplit("\\", 1)[-1].lower()
+        finally:
+            _kernel32.CloseHandle(handle)
 
+    def window_titles(exe_names: set[str]) -> list[str]:
+        """Títulos das janelas top-level visíveis pertencentes aos executáveis dados.
 
-def window_titles(exe_names: set[str]) -> list[str]:
-    """Títulos das janelas top-level visíveis pertencentes aos executáveis dados.
+        exe_names: basenames minúsculos com extensão (ex.: {"chrome.exe"}).
+        """
+        titles: list[str] = []
+        exe_cache: dict[int, str] = {}
 
-    exe_names: basenames minúsculos com extensão (ex.: {"chrome.exe"}).
-    """
-    titles: list[str] = []
-    exe_cache: dict[int, str] = {}
-
-    @ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
-    def _on_window(hwnd, _lparam):
-        # filtros baratos primeiro; OpenProcess só para janelas com título
-        if not _user32.IsWindowVisible(hwnd):
+        @ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+        def _on_window(hwnd, _lparam):
+            # filtros baratos primeiro; OpenProcess só para janelas com título
+            if not _user32.IsWindowVisible(hwnd):
+                return True
+            length = _user32.GetWindowTextLengthW(hwnd)
+            if length == 0:
+                return True
+            pid = wintypes.DWORD()
+            _user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+            exe = exe_cache.get(pid.value)
+            if exe is None:
+                exe = exe_cache.setdefault(pid.value, _exe_of_pid(pid.value))
+            if exe in exe_names:
+                buf = ctypes.create_unicode_buffer(length + 1)
+                _user32.GetWindowTextW(hwnd, buf, length + 1)
+                if buf.value:
+                    titles.append(buf.value)
             return True
-        length = _user32.GetWindowTextLengthW(hwnd)
-        if length == 0:
-            return True
-        pid = wintypes.DWORD()
-        _user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
-        exe = exe_cache.get(pid.value)
-        if exe is None:
-            exe = exe_cache.setdefault(pid.value, _exe_of_pid(pid.value))
-        if exe in exe_names:
-            buf = ctypes.create_unicode_buffer(length + 1)
-            _user32.GetWindowTextW(hwnd, buf, length + 1)
-            if buf.value:
-                titles.append(buf.value)
-        return True
 
-    _user32.EnumWindows(_on_window, 0)
-    return titles
+        _user32.EnumWindows(_on_window, 0)
+        return titles
+
+else:
+    def window_titles(exe_names: set[str]) -> list[str]:
+        """POSIX: detecção por título de janela ainda não existe (#104) — lista vazia."""
+        return []

--- a/tests/test_posix_import.py
+++ b/tests/test_posix_import.py
@@ -34,6 +34,12 @@ import scriba.cli
 import scriba.detector
 import scriba.notify
 import scriba.pipeline
+import scriba.wintitles
+import scriba.hotkey
+import scriba.autostart
+import scriba.shortcuts
+import scriba.recorder
+import scriba.audioprobe
 
 print("OK")
 """

--- a/tests/test_stubs_posix.py
+++ b/tests/test_stubs_posix.py
@@ -1,0 +1,72 @@
+"""#102: costuras de SO degradam com graça no POSIX (stubs do Marco 1, épico #104).
+
+Os guards checam sys.platform em TEMPO DE CHAMADA, então dá para exercitar o ramo
+POSIX aqui no Windows patchando sys.platform — sem tocar pyaudiowpatch/winreg/Win32.
+(Exceção: wintitles decide no import; o ramo POSIX dele só roda no CI Linux, #103.)
+"""
+
+import sys
+import unittest
+from unittest import mock
+
+from scriba import autostart, detector, hotkey, recorder, shortcuts
+
+
+def _linux():
+    return mock.patch.object(sys, "platform", "linux")
+
+
+class TestRecorderStubs(unittest.TestCase):
+    def test_record_for_degrada_com_mensagem(self):
+        with _linux(), mock.patch("builtins.print") as p:
+            self.assertEqual(recorder.record_for(5, show_ui=False), 1)
+        self.assertIn("não suportada neste SO", p.call_args[0][0])
+
+    def test_list_devices_degrada_com_mensagem(self):
+        with _linux(), mock.patch("builtins.print") as p:
+            self.assertEqual(recorder.list_devices(), 1)
+        self.assertIn("não suportada neste SO", p.call_args[0][0])
+
+    def test_recording_levanta_erro_claro(self):
+        with _linux(), self.assertRaisesRegex(RuntimeError, "não suportada neste SO"):
+            recorder.Recording(mock.Mock())
+
+
+class TestDetectorStubs(unittest.TestCase):
+    def test_debug_loop_degrada_com_mensagem(self):
+        with _linux(), mock.patch("builtins.print") as p:
+            self.assertEqual(detector.debug_loop(), 1)
+        self.assertIn("não suportada neste SO", p.call_args[0][0])
+
+    def test_thread_do_detector_sai_logando(self):
+        det = detector.Detector.__new__(detector.Detector)  # sem __init__: só o guard
+        stop = mock.Mock()
+        with _linux(), self.assertLogs("scriba.detector", level="INFO") as logs:
+            det.run(stop)
+        self.assertTrue(any("não suportada neste SO" in m for m in logs.output))
+        stop.is_set.assert_not_called()  # saiu antes do loop
+
+
+class TestHotkeyAutostartShortcuts(unittest.TestCase):
+    def test_hotkey_start_devolve_false_logando(self):
+        hk = hotkey.GlobalHotkey("ctrl+alt+r", lambda: None)
+        with _linux(), self.assertLogs("scriba.hotkey", level="INFO"):
+            self.assertFalse(hk.start())
+
+    def test_autostart_is_enabled_false(self):
+        with _linux():
+            self.assertFalse(autostart.is_enabled())
+
+    def test_autostart_set_degrada_com_mensagem(self):
+        with _linux(), mock.patch("builtins.print") as p:
+            self.assertEqual(autostart.set_autostart(True), 1)
+        self.assertIn("não suportado neste SO", p.call_args[0][0])
+
+    def test_shortcuts_degrada_com_mensagem(self):
+        with _linux(), mock.patch("builtins.print") as p:
+            self.assertEqual(shortcuts.create_shortcuts(), 1)
+        self.assertIn("não suportados neste SO", p.call_args[0][0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Oitavo degrau do epico #104 - as costuras que no Marco 1 so precisam degradar com graca fora do Windows.

**O que muda** (guards `sys.platform` em tempo de chamada; no Windows tudo e no-op)
- **recorder**: `record_for`/`list_devices` imprimem mensagem clara e saem com 1; `Recording.__init__` levanta `RuntimeError` claro (protege o caminho da GUI contra `ModuleNotFoundError` de pyaudiowpatch).
- **detector**: `debug_loop` idem; `Detector.run` (thread) sai logando - o app roda sem deteccao automatica no POSIX.
- **wintitles**: `ctypes.windll` saiu do import-time; no POSIX `window_titles` devolve lista vazia (modulo importavel).
- **hotkey**: `start()` devolve False logando. **autostart/shortcuts**: mensagem + exit 1.
- Conferidos sem mudanca: `qt/widgets` (dwmapi/Mica/exclude-from-capture ja lazy + try/except) e DPAPI (ja devolve None fora do Windows).
- `test_posix_import` agora cobre TODAS as costuras; `test_stubs_posix` (9 testes) exercita cada ramo POSIX patchando `sys.platform` - roda em qualquer SO.

**Validacao**
- Suite completa verde no Windows: 614 testes, OK.
- `scribadev record 5 --no-ui` e `scribadev detect` no Linux real serao exercitados no Cowork e travados no CI Linux (#103).

Closes #102