### PR TITLE
fix: captura de título de janela não pode pendurar detector/gravação/GUI (#114)

### DIFF
--- a/scriba/main.py
+++ b/scriba/main.py
@@ -64,6 +64,12 @@ class ScribaApp:
         self.rec: Recording | None = None
         self.rec_source = "auto"
         self.rec_lock = threading.Lock()
+        # início de gravação em andamento (#114): Recording() é montado FORA do
+        # rec_lock (abrir streams pode demorar; segurar o lock congelava a GUI).
+        # _rec_starting evita partida dupla; _pending_stop guarda um stop que
+        # chegou no meio da montagem, executado assim que ela termina.
+        self._rec_starting = False
+        self._pending_stop: dict | None = None
         self.call_active = False  # call do Teams em andamento (a pílula segue a call)
         self._app = None  # QApplication (criado em run())
         self._pump = None  # UiPump que drena a ui_queue na thread da GUI
@@ -192,16 +198,33 @@ class ScribaApp:
             self._toast("ScribaDev: áudio indisponível", "Não consegui acessar microfone/loopback agora.")
             return
         with self.rec_lock:
-            if self.rec is not None:
+            if self.rec is not None or self._rec_starting:
                 return
-            try:
-                rec = Recording(self.cfg)
-            except Exception as e:
-                log.exception("falha ao iniciar gravação")
-                self._toast("ScribaDev: erro ao iniciar gravação", str(e))
-                return
-            self.rec = rec
-            self.rec_source = source
+            # reserva o slot e SOLTA o lock: montar Recording() abre streams e pode
+            # demorar — segurá-lo aqui congelava is_recording()/_tick da GUI quando
+            # algo nativo pendurava a montagem (#114)
+            self._rec_starting = True
+            self._pending_stop = None
+        rec = None
+        try:
+            rec = Recording(self.cfg)
+        except Exception as e:
+            log.exception("falha ao iniciar gravação")
+            self._toast("ScribaDev: erro ao iniciar gravação", str(e))
+            return
+        finally:
+            with self.rec_lock:
+                pending = self._pending_stop
+                self._pending_stop = None
+                self._rec_starting = False
+                if rec is not None:
+                    self.rec = rec
+                    self.rec_source = source
+        if pending is not None:
+            # a call terminou enquanto a gravação nascia: encerra pelo fluxo normal
+            log.info("stop chegou durante o início da gravação — encerrando já")
+            self.stop_recording(**pending)
+            return
         log.info("gravação iniciada (%s): %s", source, rec.folder.name)
         self._toast("Gravando reunião", "O áudio está sendo capturado localmente.")
         if self.tray:
@@ -220,6 +243,11 @@ class ScribaApp:
         with self.rec_lock:
             rec, source = self.rec, self.rec_source
             self.rec = None
+            if rec is None and self._rec_starting:
+                # gravação ainda nascendo (#114): registra a intenção — o
+                # start_recording encerra assim que a montagem terminar
+                self._pending_stop = {"discard": discard, "keep": keep}
+                return
         if rec is None:
             return
         if self.tray:

--- a/scriba/recorder.py
+++ b/scriba/recorder.py
@@ -320,13 +320,34 @@ class Recording:
         except Exception:
             self.pa.terminate()
             raise
+        # Título da reunião é COSMÉTICO e vem de EnumWindows, que pode pendurar se
+        # outro processo estiver travado (#114). A gravação nasce JÁ (meta escrito,
+        # pílula aparece); o título é capturado em thread e regrava o meta ao chegar.
+        self.meeting_title = ""
+        self._meta_lock = threading.Lock()
+        self._meta_final = False  # stop() já gravou o meta final — não sobrescrever
+        self._write_meta("recording")
+        threading.Thread(target=self._capture_title_async, args=(cfg.detection,),
+                         daemon=True, name="meetingtitle").start()
+
+    def _capture_title_async(self, detection_cfg) -> None:
+        """Captura o título da janela da reunião FORA do caminho crítico (#114).
+
+        Falha/atraso nunca afeta a gravação: no pior caso a nota fica sem
+        meeting_title. Se o título chegar depois do stop(), é descartado —
+        reescrever o meta final poderia regredir o status."""
         try:
             from .detector import capture_meeting_title
 
-            self.meeting_title = capture_meeting_title(cfg.detection)
+            title = capture_meeting_title(detection_cfg)
         except Exception:
-            self.meeting_title = ""
-        self._write_meta("recording")
+            return
+        if not title:
+            return
+        with self._meta_lock:
+            self.meeting_title = title
+            if not self._meta_final:
+                self._write_meta("recording")
 
     def _new_folder(self) -> Path:
         # árvore ano/mês/dia + pasta HH-MM da gravação (":" não é válido em nome
@@ -415,13 +436,17 @@ class Recording:
         self.mic.stop()
         self.loopback.stop()
         self.pa.terminate()
-        self._write_meta(
-            status,
-            {
-                "ended_at": datetime.now().isoformat(timespec="seconds"),
-                "duration_seconds": round(duration, 1),
-            },
-        )
+        # sob o lock do meta (#114): a thread do título não pode regravar
+        # "recording" por cima do meta final depois deste ponto
+        with self._meta_lock:
+            self._meta_final = True
+            self._write_meta(
+                status,
+                {
+                    "ended_at": datetime.now().isoformat(timespec="seconds"),
+                    "duration_seconds": round(duration, 1),
+                },
+            )
         return {"folder": self.folder, "duration_seconds": duration, "status": status}
 
 

--- a/scriba/wintitles.py
+++ b/scriba/wintitles.py
@@ -3,11 +3,32 @@
 Usado pela detecção de calls em navegador: o registro do mic só diz que
 "chrome.exe está com o microfone aberto" — é o título de alguma janela do
 navegador (a aba ativa) que diz SE aquilo é uma reunião (Meet, Teams web...).
+
+À prova de travamento (#114): `EnumWindows` pode BLOQUEAR indefinidamente quando
+algum processo com janela top-level está travado segurando locks do window manager
+(aconteceu em produção: pendurou o thread do detector dentro do início da gravação
+e congelou o app inteiro). Título de janela é sempre cosmético/best-effort, então
+a enumeração roda numa thread própria com prazo: estourou, devolve lista vazia e
+segue a vida — a thread presa é abandonada (daemon) e nenhuma nova enumeração é
+empilhada enquanto ela não morrer.
 """
 
 from __future__ import annotations
 
+import logging
 import sys
+import threading
+
+log = logging.getLogger("scriba.wintitles")
+
+# Prazo da enumeração. Normalmente ela leva poucos ms; segundos = algo travado.
+_ENUM_TIMEOUT_S = 1.5
+
+# Threads de enumeração abandonadas por timeout que ainda não morreram. Enquanto
+# houver uma viva, novas chamadas devolvem [] direto — sem empilhar uma thread
+# presa a cada poll do detector (2 s) durante um travamento longo do sistema.
+_stuck_lock = threading.Lock()
+_stuck: list[threading.Thread] = []
 
 if sys.platform == "win32":
     import ctypes
@@ -32,8 +53,8 @@ if sys.platform == "win32":
         finally:
             _kernel32.CloseHandle(handle)
 
-    def window_titles(exe_names: set[str]) -> list[str]:
-        """Títulos das janelas top-level visíveis pertencentes aos executáveis dados.
+    def _enum_titles(exe_names: set[str]) -> list[str]:
+        """Enumeração crua (pode bloquear — só chamar via window_titles).
 
         exe_names: basenames minúsculos com extensão (ex.: {"chrome.exe"}).
         """
@@ -64,6 +85,41 @@ if sys.platform == "win32":
         return titles
 
 else:
-    def window_titles(exe_names: set[str]) -> list[str]:
+    def _enum_titles(exe_names: set[str]) -> list[str]:
         """POSIX: detecção por título de janela ainda não existe (#104) — lista vazia."""
         return []
+
+
+def window_titles(exe_names: set[str], timeout_s: float = _ENUM_TIMEOUT_S) -> list[str]:
+    """Títulos das janelas top-level visíveis dos executáveis dados — com prazo.
+
+    Roda `_enum_titles` numa thread daemon e espera no máximo `timeout_s` (#114):
+    estourou o prazo (EnumWindows pendurado por um processo travado), devolve []
+    e abandona a thread — quem chama segue sem título, nunca congela. Falha da
+    enumeração também vira [] (título é cosmético, jamais derruba a detecção).
+    """
+    with _stuck_lock:
+        _stuck[:] = [t for t in _stuck if t.is_alive()]
+        if _stuck:
+            # enumeração anterior ainda pendurada: não adianta (e não é seguro)
+            # empilhar outra — o window manager segue travado
+            return []
+
+    box: dict[str, list[str]] = {}
+
+    def _work() -> None:
+        try:
+            box["titles"] = _enum_titles(exe_names)
+        except Exception:
+            log.debug("enumeração de janelas falhou", exc_info=True)
+
+    t = threading.Thread(target=_work, daemon=True, name="wintitles")
+    t.start()
+    t.join(timeout_s)
+    if t.is_alive():
+        with _stuck_lock:
+            _stuck.append(t)
+        log.warning("enumeração de janelas não respondeu em %.1fs — seguindo sem títulos (#114)",
+                    timeout_s)
+        return []
+    return box.get("titles", [])

--- a/tests/test_wintitles.py
+++ b/tests/test_wintitles.py
@@ -1,0 +1,159 @@
+"""Testes de scriba.wintitles (#114): enumeração de janelas com prazo.
+
+EnumWindows pode bloquear indefinidamente quando um processo com janela top-level
+está travado (aconteceu em produção: pendurou o detector dentro do início da
+gravação e congelou o app). window_titles roda a enumeração numa thread com
+timeout; estes testes cobrem o contrato — timeout devolve [], enumeração presa
+não empilha novas threads, e o caminho feliz passa o resultado adiante.
+"""
+
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scriba import wintitles  # noqa: E402
+
+
+class WindowTitlesTimeoutTests(unittest.TestCase):
+    def setUp(self):
+        self._orig = wintitles._enum_titles
+        self._release = threading.Event()  # solta a enumeração "presa" no teardown
+
+    def tearDown(self):
+        self._release.set()
+        wintitles._enum_titles = self._orig
+        # espera as threads abandonadas morrerem p/ não vazar entre testes
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            with wintitles._stuck_lock:
+                wintitles._stuck[:] = [t for t in wintitles._stuck if t.is_alive()]
+                if not wintitles._stuck:
+                    break
+            time.sleep(0.01)
+
+    def test_caminho_feliz_passa_o_resultado(self):
+        wintitles._enum_titles = lambda names: ["Reunião - Google Meet"]
+        self.assertEqual(wintitles.window_titles({"chrome.exe"}), ["Reunião - Google Meet"])
+
+    def test_enumeracao_presa_devolve_vazio_no_prazo(self):
+        def presa(names):
+            self._release.wait(10)  # simula EnumWindows pendurado
+            return ["tarde demais"]
+
+        wintitles._enum_titles = presa
+        t0 = time.monotonic()
+        self.assertEqual(wintitles.window_titles({"chrome.exe"}, timeout_s=0.2), [])
+        self.assertLess(time.monotonic() - t0, 2.0, "timeout não respeitado")
+
+    def test_presa_anterior_bloqueia_novas_enumeracoes(self):
+        chamadas = []
+
+        def presa(names):
+            chamadas.append(1)
+            self._release.wait(10)
+            return []
+
+        wintitles._enum_titles = presa
+        self.assertEqual(wintitles.window_titles({"chrome.exe"}, timeout_s=0.2), [])
+        # com a anterior ainda presa, nem tenta outra (não empilha thread por poll)
+        self.assertEqual(wintitles.window_titles({"chrome.exe"}, timeout_s=0.2), [])
+        self.assertEqual(len(chamadas), 1)
+
+    def test_enumeracao_que_explode_devolve_vazio(self):
+        def boom(names):
+            raise OSError("user32 indisponível")
+
+        wintitles._enum_titles = boom
+        self.assertEqual(wintitles.window_titles({"chrome.exe"}), [])
+
+    def test_apos_presa_morrer_volta_a_enumerar(self):
+        def presa(names):
+            self._release.wait(10)
+            return []
+
+        wintitles._enum_titles = presa
+        wintitles.window_titles({"chrome.exe"}, timeout_s=0.2)
+        self._release.set()
+        time.sleep(0.05)  # deixa a thread presa terminar
+        wintitles._enum_titles = lambda names: ["viva de novo"]
+        self.assertEqual(wintitles.window_titles({"chrome.exe"}), ["viva de novo"])
+
+
+class TituloAssincronoMetaTests(unittest.TestCase):
+    """Recording._capture_title_async (#114): o título regrava o meta enquanto a
+    gravação está ativa e é DESCARTADO se chegar depois do stop (não pode regravar
+    'recording' por cima do meta final). Usa uma instância oca de Recording — sem
+    abrir áudio real."""
+
+    def _hollow_recording(self, tmp: Path):
+        import json
+        from types import SimpleNamespace
+
+        from scriba.recorder import Recording
+
+        rec = Recording.__new__(Recording)
+        rec.folder = tmp
+        rec.started_at = __import__("datetime").datetime(2026, 7, 10, 9, 0, 0)
+        rec.meeting_title = ""
+        rec._meta_lock = threading.Lock()
+        rec._meta_final = False
+        stream = SimpleNamespace(
+            wav=SimpleNamespace(path=Path("mic.wav"), frames_written=16000),
+            device_name="fake", rate=16000, channels=1, offset_seconds=0.0,
+        )
+        rec.mic = stream
+        rec.loopback = SimpleNamespace(
+            wav=SimpleNamespace(path=Path("loopback.wav"), frames_written=16000),
+            device_name="fake", rate=16000, channels=1, offset_seconds=0.0,
+        )
+        rec._read_meta = lambda: json.loads((tmp / "meta.json").read_text(encoding="utf-8"))
+        return rec
+
+    def test_titulo_regrava_meta_enquanto_grava(self):
+        import json
+        import tempfile
+
+        from scriba import detector
+
+        tmp = Path(tempfile.mkdtemp(prefix="scriba_title_"))
+        rec = self._hollow_recording(tmp)
+        rec._write_meta("recording")
+        orig = detector.capture_meeting_title
+        detector.capture_meeting_title = lambda cfg: "Reunião de teste"
+        try:
+            rec._capture_title_async(None)
+        finally:
+            detector.capture_meeting_title = orig
+        meta = json.loads((tmp / "meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta.get("meeting_title"), "Reunião de teste")
+        self.assertEqual(meta.get("status"), "recording")
+
+    def test_titulo_tardio_nao_regrava_meta_final(self):
+        import json
+        import tempfile
+
+        from scriba import detector
+
+        tmp = Path(tempfile.mkdtemp(prefix="scriba_title_"))
+        rec = self._hollow_recording(tmp)
+        # simula o stop(): meta final gravado e trancado
+        with rec._meta_lock:
+            rec._meta_final = True
+            rec._write_meta("recorded", {"duration_seconds": 12.3})
+        orig = detector.capture_meeting_title
+        detector.capture_meeting_title = lambda cfg: "chegou tarde"
+        try:
+            rec._capture_title_async(None)
+        finally:
+            detector.capture_meeting_title = orig
+        meta = json.loads((tmp / "meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta.get("status"), "recorded", "título tardio regrediu o status")
+        self.assertNotIn("meeting_title", meta)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #114

## O problema

Em produção (10/07), `EnumWindows` pendurou dentro de `capture_meeting_title` no início da gravação.
Como a captura de título rodava dentro de `Recording.__init__`, que rodava dentro do `rec_lock`, a cascata foi:
gravação nunca registrada (meta.json não escrito, pílula não apareceu), thread do detector morta, e GUI congelada (o `_tick` bloqueia em `is_recording()` → `rec_lock`).
O watchdog capturou as pilhas em `hang.log`.

## A correção (defesa em profundidade, 3 camadas)

**1. `wintitles.py` — enumeração com prazo.**
`window_titles` agora roda a enumeração (`_enum_titles`) numa thread daemon com timeout (1,5s).
Estourou → devolve `[]` e abandona a thread; enquanto uma enumeração presa não morrer, novas chamadas devolvem `[]` direto (não empilha uma thread por poll do detector).
Isso protege TODOS os chamadores (detector: confirmação de call no navegador, tracking de título; recorder: título da nota) de uma vez.

**2. `recorder.py` — título fora do caminho crítico.**
O título da reunião é cosmético. `Recording.__init__` agora escreve o meta e retorna imediatamente; a captura do título roda numa thread daemon (`_capture_title_async`) que regrava o meta quando o título chega.
Um lock (`_meta_lock`) + flag (`_meta_final`) garantem que um título tardio nunca regrava "recording" por cima do meta final do `stop()`.

**3. `main.py` — `Recording()` fora do `rec_lock`.**
`start_recording` reserva o slot (`_rec_starting`) e solta o lock antes de montar o `Recording` — `is_recording()`/`_tick` da GUI nunca mais bloqueiam numa montagem lenta.
Um `stop_recording` que chegue durante a montagem registra a intenção (`_pending_stop`) e o start encerra a gravação assim que ela nasce (cobre a corrida "call terminou enquanto a gravação nascia").

## Testes

`tests/test_wintitles.py` (novo, 7 testes): timeout devolve `[]` no prazo, enumeração presa não empilha novas, recuperação após a thread presa morrer, exceção vira `[]`, caminho feliz; e o contrato do título assíncrono no meta (regrava enquanto grava, descartado após o stop).
Suíte completa verde.

## Fora de escopo (mencionado na issue como opcional)

Estender o watchdog para o thread do detector — deixado para uma issue própria se ainda fizer sentido após esta correção (o cenário que motivava já não trava mais).
