### PR TITLE
fix: diarização aborta em erro de driver CUDA e não martela GPU ferida (#115)

### DIFF
--- a/scriba/cli.py
+++ b/scriba/cli.py
@@ -97,6 +97,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_proc.add_argument("--speakers", type=int, default=None, metavar="N",
                         help="nº de participantes remotos: trava a diarização em N vozes (persiste no meta)")
+    p_proc.add_argument("--cpu", action="store_true",
+                        help="força transcrição E diarização em CPU (#115: recuperação pós-erro de GPU)")
 
     p_split = sub.add_parser(
         "split", help="corta uma reunião já processada em duas no offset dado (#37)"
@@ -175,7 +177,7 @@ def main(argv: list[str] | None = None) -> int:
         _timestamp_subprocess_output()  # process.log com HH:MM:SS por linha
         if args.when_ready:
             return process_when_ready(args.folder)
-        return 0 if process_folder(args.folder, num_speakers=args.speakers) else 1
+        return 0 if process_folder(args.folder, force_cpu=args.cpu, num_speakers=args.speakers) else 1
     if args.cmd == "run":
         from .main import run_app
 

--- a/scriba/diarize.py
+++ b/scriba/diarize.py
@@ -8,6 +8,7 @@ página do modelo — depois disso, o download acontece uma vez e o resto é off
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -99,11 +100,13 @@ def test_token(model: str, token: str) -> tuple[bool, str]:
 
 
 def diarize(wav: Path, cfg: Diarization, num_speakers: int | None = None,
-            meta: dict | None = None) -> DiarizationResult | None:
+            meta: dict | None = None, force_cpu: bool = False) -> DiarizationResult | None:
     """Trechos por voz do arquivo, ou None se desabilitado/indisponível (segue sem separar).
 
     num_speakers: nº de vozes remotas (loopback) informado pelo usuário — trava a
     diarização nesse número. None = automático (ou max_speakers do config).
+    force_cpu: roda o pyannote em CPU mesmo com CUDA disponível (#115) — o caminho
+    de recuperação após um erro de driver na GPU (`scribadev transcribe --cpu`).
 
     Devolve um DiarizationResult (turns + embeddings por voz) para o enrollment
     da issue #1 — ou None se a diarização não rodou.
@@ -134,6 +137,7 @@ def diarize(wav: Path, cfg: Diarization, num_speakers: int | None = None,
         _fail(f"dependências ausentes — falta o extra [diarization] ({e})")
         return None
     pipe = None
+    ctx_broken = False  # erro de driver/contexto (#115): não tocar mais na GPU
     try:
         try:
             pipe = Pipeline.from_pretrained(cfg.model, token=cfg.hf_token)
@@ -150,7 +154,9 @@ def diarize(wav: Path, cfg: Diarization, num_speakers: int | None = None,
             _fail(f"modelo indisponível — confirme que aceitou os termos de {cfg.model} no "
                   "Hugging Face com a conta do token")
             return None
-        if torch.cuda.is_available():
+        if force_cpu and torch.cuda.is_available():
+            print("diarização em CPU (forçada com --cpu)")
+        if torch.cuda.is_available() and not force_cpu:
             pipe.to(torch.device("cuda"))
             # blinda contra o sysmem fallback do Windows (spill VRAM->RAM = freeze):
             # capa o allocator do PyTorch com uma margem livre, então VRAM apertada/
@@ -181,6 +187,14 @@ def diarize(wav: Path, cfg: Diarization, num_speakers: int | None = None,
         voices = {label for *_x, label in turns}
         print(f"diarização: {len(voices)} voz(es) distintas em {len(turns)} trechos")
         return DiarizationResult(turns=turns, embeddings=embeddings)
+    except _CudaContextError as e:
+        # Erro de DRIVER/CONTEXTO (#115): abortar é a proteção — continuar
+        # submetendo trabalho a um contexto corrompido escalou para TDR/perda
+        # de vídeo em produção. A nota sai normal, sem separação de voz.
+        ctx_broken = True
+        _fail(f"erro de driver/contexto CUDA ({e}) — abortada para proteger a GPU; "
+              "reprocesse com 'scribadev transcribe <pasta> --cpu' para diarizar em CPU")
+        return None
     except Exception as e:
         _fail(f"falhou ({type(e).__name__}: {e}); seguindo com 'Participantes'", exc=True)
         return None
@@ -189,13 +203,16 @@ def diarize(wav: Path, cfg: Diarization, num_speakers: int | None = None,
         # segura ~1-2 GB durante o resumo (claude -p) e o arquivamento (ffmpeg), que
         # rodam depois no MESMO processo do pipeline. (O contexto CUDA do torch em si,
         # ~0,5-1 GB, só sai quando o subprocesso encerra — aí é inevitável.)
-        _uncap_pyannote_vram()  # restaura a fração do allocator (o cap valia só aqui)
+        # Com o contexto QUEBRADO (#115), NADA de CUDA aqui: até empty_cache/uncap
+        # submeteria chamadas ao driver ferido.
+        if not ctx_broken:
+            _uncap_pyannote_vram()  # restaura a fração do allocator (o cap valia só aqui)
         pipe = None
         try:
             import gc
 
             gc.collect()
-            if torch.cuda.is_available():
+            if not ctx_broken and torch.cuda.is_available():
                 torch.cuda.empty_cache()
         except Exception:
             pass
@@ -293,6 +310,84 @@ def _free_cuda() -> None:
         pass
 
 
+# ---- proteção de GPU (issue #115) -------------------------------------------
+# OOM é recuperável (libera cache e pula o bloco); erro de DRIVER/CONTEXTO não é:
+# o contexto CUDA fica corrompido e continuar submetendo kernels leva a TDR/perda
+# de vídeo (aconteceu em produção: 85°C + cudaErrorUnknown em série no fim de uma
+# diarização de ~112 min + driver travado = máquina desligada no botão).
+
+class _CudaContextError(RuntimeError):
+    """Contexto CUDA corrompido (erro de driver): abortar a diarização inteira e
+    NÃO tocar mais na GPU neste processo (nem empty_cache)."""
+
+
+_CTX_ERROR_MARKERS = (
+    "cuda error", "cudaerror", "device-side assert", "illegal memory access",
+    "unspecified launch failure", "misaligned address", "cudnn error",
+)
+
+
+def _is_cuda_context_error(e: BaseException) -> bool:
+    """Erro de driver/contexto CUDA? (≠ OOM/alloc, que é recuperável por bloco)."""
+    msg = str(e).lower()
+    if "out of memory" in msg or "alloc" in msg:  # OOM e afins: recuperável
+        return False
+    try:
+        import torch
+
+        if isinstance(e, torch.cuda.OutOfMemoryError):
+            return False
+    except Exception:
+        pass
+    return any(m in msg for m in _CTX_ERROR_MARKERS)
+
+
+# Pacing térmico entre blocos (#115): a diarização chunked mantém a GPU a 100%
+# por dezenas de minutos em áudio longo. Um respiro por bloco + pausa quando a
+# temperatura passa do limiar evita o full-throttle sustentado que derrubou o
+# driver em produção. Tudo best-effort: sem nvidia-smi, fica só o respiro.
+_BLOCK_YIELD_S = 0.5     # respiro fixo entre blocos
+_TEMP_SOFT_C = 80        # acima disso, espera esfriar...
+_TEMP_RESUME_C = 74      # ...até voltar para cá
+_TEMP_MAX_WAIT_S = 60    # teto da espera (termômetro nunca trava o pipeline)
+_MAX_CONSECUTIVE_FAILS = 3  # blocos falhando em série: desiste (não insiste na GPU ferida)
+
+
+def _gpu_temperature() -> int | None:
+    """Temperatura da GPU em °C via nvidia-smi (None se indisponível)."""
+    import shutil
+    import subprocess
+
+    exe = shutil.which("nvidia-smi")
+    if not exe:
+        return None
+    try:
+        out = subprocess.run(
+            [exe, "--query-gpu=temperature.gpu", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=5,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+        return int(out.stdout.strip().splitlines()[0])
+    except Exception:
+        return None
+
+
+def _thermal_pause() -> None:
+    """Respiro entre blocos; se a GPU estiver quente, espera esfriar (limitado)."""
+    time.sleep(_BLOCK_YIELD_S)
+    t = _gpu_temperature()
+    if t is None or t < _TEMP_SOFT_C:
+        return
+    log.warning("diarização: GPU a %d°C — pausando até esfriar (<%d°C)", t, _TEMP_RESUME_C)
+    print(f"GPU a {t}°C — pausa para resfriar antes do próximo bloco...")
+    deadline = time.monotonic() + _TEMP_MAX_WAIT_S
+    while time.monotonic() < deadline:
+        time.sleep(5)
+        t = _gpu_temperature()
+        if t is None or t <= _TEMP_RESUME_C:
+            return
+
+
 # Margem de VRAM (MB) deixada LIVRE no device durante a diarização. O working-set
 # medido do pyannote é ~3,3 GB/bloco; capar o allocator do PyTorch nesse teto faz um
 # bloco pesado (ou VRAM já apertada por outra app) levantar um OutOfMemoryError
@@ -388,20 +483,38 @@ def _diarize_chunked(pipe, audio, sr: int, chunk_s: int) -> tuple[list[Turn], di
 
     globals_: list = []          # [centroide(np), n_amostras, id global] por voz da call
     all_turns: list[Turn] = []
+    consecutive_fails = 0
     for i in range(n_chunks):
         a, b = i * chunk_n, min((i + 1) * chunk_n, total)
         offset = a / sr
         try:
             out = _run_pipe(pipe, {"waveform": wav[:, a:b].clone(), "sample_rate": sr}, {})
         except Exception as e:
+            if _is_cuda_context_error(e):
+                # Contexto CUDA corrompido (#115): NÃO submeter mais NADA à GPU —
+                # nem empty_cache. Aborta tudo; diarize() degrada p/ "Participantes".
+                raise _CudaContextError(f"bloco {i + 1}/{n_chunks}: {e}") from e
             # Resiliência por bloco: um bloco que falha (ex.: OOM sob VRAM apertada —
             # com o cap, o spill->freeze vira um OutOfMemoryError) NÃO derruba a call
             # inteira. Pula só este trecho (cai em "Participantes") e segue com os
             # demais. Antes, o erro subia e zerava TODA a diarização (issue #8).
+            consecutive_fails += 1
             _free_cuda()
             log.warning("diarização: bloco %d/%d falhou (%s); pulando este trecho", i + 1, n_chunks, e)
+            if consecutive_fails >= _MAX_CONSECUTIVE_FAILS:
+                # Insistir numa GPU que só falha piora o estado do driver (#115):
+                # para aqui e mantém o que já foi separado (blocos bons ficam;
+                # o resto cai em "Participantes").
+                log.warning("diarização: %d blocos consecutivos falharam — parando; "
+                            "trechos já separados são mantidos", consecutive_fails)
+                print(f"AVISO: diarização interrompida após {consecutive_fails} falhas seguidas — "
+                      "os trechos já separados são mantidos")
+                break
             continue
+        consecutive_fails = 0
         _free_cuda()             # solta o pico de trabalho do bloco antes do próximo
+        if i + 1 < n_chunks:
+            _thermal_pause()     # respiro/espera térmica entre blocos (#115)
         if out is None:
             continue
         turns, embs = out

--- a/scriba/pipeline.py
+++ b/scriba/pipeline.py
@@ -101,7 +101,8 @@ def transcribe_folder(folder: Path, force_cpu: bool = False, transcriber: Transc
         # marca o estágio antes de carregar o pyannote: a UI mostra "Separando vozes…"
         _set_status(meta, meta_path, "diarizing")
         lb_segments = next((seg for st, _sp, seg, _off in pending if st == "loopback"), [])
-        dz_result = diarize_mod.diarize(loopback_wav, cfg.diarization, num_speakers=num_speakers, meta=meta)
+        dz_result = diarize_mod.diarize(loopback_wav, cfg.diarization, num_speakers=num_speakers,
+                                        meta=meta, force_cpu=force_cpu)  # --cpu vale p/ a diarização também (#115)
         if dz_result and dz_result.turns:
             meta.pop("diarization_error", None)  # sucesso: limpa erro de tentativa anterior
             diarized_groups, order = diarize_mod.assign_speakers(lb_segments, dz_result.turns)

--- a/tests/test_diarize_guard.py
+++ b/tests/test_diarize_guard.py
@@ -1,0 +1,142 @@
+"""Testes da proteção de GPU na diarização (#115).
+
+Em produção, blocos falhando com cudaErrorUnknown foram "pulados" e a diarização
+seguiu martelando uma GPU de contexto já corrompido — escalou para TDR/perda de
+vídeo. Estes testes travam o novo contrato: erro de driver/contexto ABORTA tudo
+(sem mais submissões à GPU), OOM segue recuperável por bloco, e falhas em série
+desistem mantendo o que já foi separado.
+"""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scriba import diarize  # noqa: E402
+
+_HAS_NUMPY = importlib.util.find_spec("numpy") is not None
+
+
+class ClassificacaoDeErroTests(unittest.TestCase):
+    def test_oom_nao_e_erro_de_contexto(self):
+        self.assertFalse(diarize._is_cuda_context_error(RuntimeError("CUDA out of memory.")))
+
+    def test_alloc_failed_nao_e_erro_de_contexto(self):
+        self.assertFalse(diarize._is_cuda_context_error(
+            RuntimeError("CUBLAS_STATUS_ALLOC_FAILED when calling cublasCreate")))
+
+    def test_cuda_unknown_error_e_erro_de_contexto(self):
+        # a mensagem real do incidente em produção
+        self.assertTrue(diarize._is_cuda_context_error(
+            RuntimeError("CUDA error: unknown error\nCUDA kernel errors might be...")))
+
+    def test_device_side_assert_e_erro_de_contexto(self):
+        self.assertTrue(diarize._is_cuda_context_error(
+            RuntimeError("CUDA error: device-side assert triggered")))
+
+    def test_illegal_memory_access_e_erro_de_contexto(self):
+        self.assertTrue(diarize._is_cuda_context_error(
+            RuntimeError("CUDA error: an illegal memory access was encountered")))
+
+    def test_erro_generico_nao_e_de_contexto(self):
+        self.assertFalse(diarize._is_cuda_context_error(ValueError("waveform vazio")))
+
+
+class _FakeWav:
+    """Imita o tensor (1, N) só no que _diarize_chunked usa: shape e fatiamento."""
+
+    def __init__(self, n: int):
+        self.shape = (1, n)
+
+    def __getitem__(self, key):
+        return self
+
+    def clone(self):
+        return self
+
+
+@unittest.skipUnless(_HAS_NUMPY, "numpy não instalado")
+class ChunkedGuardTests(unittest.TestCase):
+    """_diarize_chunked com _run_pipe/_free_cuda/_thermal_pause dublados."""
+
+    SR = 16000
+    CHUNK_S = 60
+
+    def setUp(self):
+        self._orig = (diarize._run_pipe, diarize._free_cuda, diarize._thermal_pause)
+        diarize._free_cuda = lambda: None
+        diarize._thermal_pause = lambda: None
+        self.audio = {"waveform": _FakeWav(5 * self.CHUNK_S * self.SR),  # 5 blocos
+                      "sample_rate": self.SR}
+
+    def tearDown(self):
+        diarize._run_pipe, diarize._free_cuda, diarize._thermal_pause = self._orig
+
+    def _run(self):
+        return diarize._diarize_chunked(None, self.audio, self.SR, self.CHUNK_S)
+
+    def test_erro_de_contexto_aborta_tudo(self):
+        chamadas = []
+
+        def pipe_quebrado(pipe, audio, kwargs):
+            chamadas.append(1)
+            raise RuntimeError("CUDA error: unknown error")
+
+        diarize._run_pipe = pipe_quebrado
+        with self.assertRaises(diarize._CudaContextError):
+            self._run()
+        # abortou no 1º bloco: nenhuma submissão extra à GPU ferida
+        self.assertEqual(len(chamadas), 1)
+
+    def test_oom_em_serie_desiste_sem_insistir(self):
+        chamadas = []
+
+        def pipe_oom(pipe, audio, kwargs):
+            chamadas.append(1)
+            raise RuntimeError("CUDA out of memory. Tried to allocate 2.00 GiB")
+
+        diarize._run_pipe = pipe_oom
+        turns, embeddings = self._run()
+        self.assertEqual(turns, [])
+        self.assertEqual(embeddings, {})
+        # desistiu no teto de falhas consecutivas, não tentou os 5 blocos
+        self.assertEqual(len(chamadas), diarize._MAX_CONSECUTIVE_FAILS)
+
+    def test_bloco_bom_zera_o_contador_e_mantem_parciais(self):
+        seq = iter(["ok", "oom", "oom", "ok", "ok"])
+
+        def pipe_misto(pipe, audio, kwargs):
+            if next(seq) == "oom":
+                raise RuntimeError("CUDA out of memory.")
+            return ([(0.0, 1.0, "SPEAKER_00")], {})
+
+        diarize._run_pipe = pipe_misto
+        turns, _ = self._run()
+        # 2 falhas < teto (3) no meio não derrubam; os 3 blocos bons ficam
+        self.assertEqual(len(turns), 3)
+
+    def test_oom_espalhado_nao_desiste(self):
+        seq = iter(["oom", "ok", "oom", "ok", "oom"])
+
+        def pipe_intercalado(pipe, audio, kwargs):
+            if next(seq) == "oom":
+                raise RuntimeError("CUDA out of memory.")
+            return ([(0.0, 1.0, "SPEAKER_00")], {})
+
+        diarize._run_pipe = pipe_intercalado
+        turns, _ = self._run()
+        self.assertEqual(len(turns), 2)  # os 2 blocos bons, sem bail
+
+
+class ForceCpuTests(unittest.TestCase):
+    def test_diarize_desabilitada_ignora_force_cpu(self):
+        from scriba.config import Diarization
+
+        cfg = Diarization(enabled=False)
+        self.assertIsNone(diarize.diarize(Path("nao-existe.wav"), cfg, force_cpu=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #115

## O problema

Diarizando ~112 min (8 vozes), blocos do fim falharam em série com `cudaErrorUnknown`.
A resiliência por bloco (do épico #8, pensada para OOM) tratou cada falha como "pula e segue" — e seguiu submetendo kernels a um contexto CUDA já corrompido.
Resultado em produção: GPU a 85°C em full-throttle sustentado, driver travado (TDR), perda de vídeo, máquina desligada no botão.

## A correção

**1. Erro de driver/contexto ≠ OOM (`_is_cuda_context_error`).**
OOM/alloc continua recuperável por bloco (comportamento do #8, intacto).
`cudaErrorUnknown`, device-side assert, illegal memory access etc. agora levantam `_CudaContextError`: a diarização inteira aborta na hora, **sem nenhuma submissão a mais à GPU** — nem `empty_cache`, nem o uncap do allocator (o `finally` pula tudo que toca CUDA quando o contexto quebrou).
A nota sai normal, sem separação de voz, com a dica de recuperação no erro (`scribadev transcribe <pasta> --cpu`).

**2. Teto de falhas consecutivas.**
3 blocos falhando em série (mesmo OOM) = desiste, mantendo os trechos já separados (blocos bons ficam; o resto cai em "Participantes").
Antes, insistia até o último bloco.

**3. Pacing térmico entre blocos.**
Respiro fixo (0,5s) entre blocos + leitura de temperatura via `nvidia-smi` (best-effort): acima de 80°C, pausa até voltar a 74°C (máx. 60s — o termômetro nunca trava o pipeline).
Evita o 100% sustentado por dezenas de minutos em áudio longo.

**4. Fallback CPU de verdade.**
`force_cpu` agora chega à diarização: `scribadev transcribe --cpu` e o novo `scribadev process --cpu` rodam o pyannote em CPU (antes o `--cpu` só valia para o Whisper e a diarização ia para a GPU mesmo assim).

## Testes

`tests/test_diarize_guard.py` (novo, 11 testes): classificação de erros (OOM/alloc vs unknown/assert/illegal), abort no 1º erro de contexto sem submissões extras, bail após 3 falhas consecutivas, contador zerando em bloco bom (parciais mantidos), OOM espalhado não desiste, e `force_cpu` no caminho desabilitado.
Suíte completa verde.

## Contexto

Descoberto ao recuperar a call que o #114 quebrou (diarização de 112 min de uma vez), mas qualquer reunião real longa (teto: `max_call_hours = 4`) cai no mesmo cenário.
