### PR TITLE
fix(qt): icone do app em todas as janelas (wizard de 1o uso abria sem icone)

### DIFF
--- a/scriba/qt/main_window.py
+++ b/scriba/qt/main_window.py
@@ -196,10 +196,6 @@ class MainWindow(QWidget):
         self.setWindowTitle(f"ScribaDev v{__version__}")
         self.setMinimumSize(520, 560)
         widgets.remember_geometry(self, "qt_main", default=(200, 120, 580, 680))
-        try:
-            self.setWindowIcon(util_icon())
-        except Exception:
-            pass
 
         root = QVBoxLayout(self)
         root.setContentsMargins(18, 14, 18, 12)
@@ -1099,15 +1095,6 @@ class MainWindow(QWidget):
         """O X tira da barra mas o app segue na bandeja (paridade com WM_DELETE_WINDOW)."""
         event.ignore()
         self.hide()
-
-
-def util_icon():
-    from PySide6.QtGui import QIcon
-
-    ico = getattr(util, "ICON_ICO", None)
-    if ico and ico.exists():
-        return QIcon(str(ico))
-    return QIcon(str(util.ICON_PNG))
 
 
 # --------------------------------------------------------------- harness ------

--- a/scriba/qt/theme.py
+++ b/scriba/qt/theme.py
@@ -752,12 +752,24 @@ def _restyle_top_levels(app) -> None:
                 log.exception("restyle_theme falhou em %s", type(w).__name__)
 
 
+def app_icon():
+    """QIcon do app (pergaminho): o .ico multi-resolução quando existe, senão o PNG."""
+    from PySide6.QtGui import QIcon
+
+    ico = util.ICON_ICO
+    return QIcon(str(ico if ico.exists() else util.ICON_PNG))
+
+
 def apply(app, theme: Theme | None = None) -> None:
     """Aplica fonte-base (Inter…) + QSS do tema ao QApplication e re-estiliza as janelas
     abertas (restyle_theme). Idempotente."""
     t = theme or active()
     app.setFont(qfont(t))
     app.setStyleSheet(qss(t))
+    # ícone default de TODA janela top-level (wizard, Notas, Config…): apply() é o
+    # chokepoint comum aos entry points (main, cli, harnesses) — sem isto, janela que
+    # não chama setWindowIcon próprio abre com o ícone genérico do SO
+    app.setWindowIcon(app_icon())
     _restyle_top_levels(app)
 
 

--- a/tests/test_qt_theme.py
+++ b/tests/test_qt_theme.py
@@ -209,6 +209,40 @@ class RestyleContractTests(unittest.TestCase):
         self.assertTrue(ok)                      # a boa ainda rodou
 
 
+@unittest.skipUnless(_HAS_PYSIDE, "PySide6 não instalado (extra 'qt')")
+class AppIconTests(unittest.TestCase):
+    """theme.apply define o ícone default do QApplication: TODA janela top-level
+    (wizard de 1º uso, Notas, Config…) nasce com o pergaminho. Regressão: o wizard
+    abria com o ícone genérico do Windows porque o ícone era por-janela (só a capa)."""
+
+    @classmethod
+    def setUpClass(cls):
+        from PySide6.QtWidgets import QApplication
+
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_app_icon_resolve_arquivo_existente(self):
+        self.assertFalse(theme.app_icon().isNull())
+
+    def test_apply_define_icone_default_do_app(self):
+        from PySide6.QtGui import QIcon
+
+        self.app.setWindowIcon(QIcon())   # zera (estado pode vir de outro teste)
+        self.assertTrue(self.app.windowIcon().isNull())
+        theme.apply(self.app)
+        self.assertFalse(self.app.windowIcon().isNull())
+
+    def test_janela_sem_icone_proprio_herda_o_do_app(self):
+        from PySide6.QtWidgets import QWidget
+
+        theme.apply(self.app)
+        w = QWidget()
+        w.setWindowTitle("qualquer janela")
+        w.show()
+        self.addCleanup(w.close)
+        self.assertFalse(w.windowIcon().isNull())
+
+
 # -- ícones Fluent vendorizados (#59) -----------------------------------------
 
 # Vocabulário que a fundação promete (scriba/qt/icons/*.svg). Se um nome sumir do


### PR DESCRIPTION
## Problema

Usuário reportou que o wizard de primeiros passos ("ScribaDev - Primeiros passos") abre com o ícone genérico do Windows na barra de título.

Causa: o ícone era definido **por janela**, e só a capa (`MainWindow`) chamava `setWindowIcon`.
Qualquer outra janela top-level (wizard de 1º uso, Notas, Configurações, Log nos harnesses) nascia sem ícone.

## Correção

- `theme.apply(app)` agora define o **ícone default do QApplication** (`app.setWindowIcon(theme.app_icon())`).
  O `apply` é o chokepoint comum a todos os entry points (app real, `scribadev wizard`, harnesses `python -m scriba.qt.*`), então toda janela sem ícone próprio herda o pergaminho - inclusive janelas futuras, sem precisar lembrar de nada.
- `theme.app_icon()`: usa o `.ico` multi-resolução quando existe, senão o PNG - mesmos assets da bandeja, então funciona igual na instalação congelada (setup.exe).
- Removidos o `setWindowIcon` por-janela da `MainWindow` e o helper `util_icon` (redundantes com o default do app).

## Testes

- `AppIconTests`: `app_icon()` resolve arquivo existente; `apply` define o default do app; janela sem ícone próprio herda.
- Smoke no próprio `SetupWizardWindow`: `windowIcon` não-nulo e com o mesmo `cacheKey` do ícone do app.
- Suíte completa: 811 testes OK (12 skipped).
