### PR TITLE
fix(qt): rotulos comidos no Log e no assistente de perfil (fontes mais largas)

### DIFF
--- a/scriba/qt/widgets.py
+++ b/scriba/qt/widgets.py
@@ -326,8 +326,17 @@ class AnimatedCheckBox(QCheckBox):
     fill = Property(float, get_fill, set_fill)
 
     def sizeHint(self) -> QSize:
+        # o texto é PINTADO à mão a partir de x = _BOX + _GAP (paintEvent): a largura
+        # herdada do QCheckBox usa o indicador do ESTILO (~20px < 27px) e nascia curta —
+        # o fim do rótulo era comido ("auto-atualiza…") em fontes mais largas
         base = super().sizeHint()
-        return QSize(base.width(), max(base.height(), self._BOX + 6))
+        w = self._BOX + 4   # box desenhado a partir de x=1 + folga à direita
+        if self.text():
+            w += self._GAP + self.fontMetrics().horizontalAdvance(self.text())
+        return QSize(max(base.width(), w), max(base.height(), self._BOX + 6))
+
+    def minimumSizeHint(self) -> QSize:
+        return self.sizeHint()   # encolher abaixo do hint = cortar o texto pintado
 
     def hitButton(self, pos) -> bool:
         return self.rect().contains(pos)   # clicar em qualquer lugar (box ou texto) alterna
@@ -364,6 +373,26 @@ class AnimatedCheckBox(QCheckBox):
             tx = box + self._GAP
             p.drawText(QRectF(tx, 0, self.width() - tx, self.height()),
                        int(Qt.AlignVCenter | Qt.AlignLeft), self.text())
+
+
+# == label com word-wrap que nunca é "comido" ================================
+
+class WrapLabel(QLabel):
+    """QLabel com word-wrap cujo texto NUNCA é cortado pelo layout no aperto.
+
+    O QLabel embrulhado anuncia heightForWidth, mas quando está aninhado (ex.:
+    dentro de um QFrame de card) o layout externo pode espremê-lo abaixo da altura
+    do texto — o meio da frase some (visto na máquina de um usuário, fontes mais
+    largas). A cada resize impõe minimumHeight = heightForWidth(largura atual):
+    o aperto vai p/ os vizinhos que sabem ceder (scroll), nunca p/ o texto."""
+
+    def __init__(self, text: str = "", parent=None):
+        super().__init__(text, parent)
+        self.setWordWrap(True)
+
+    def resizeEvent(self, e) -> None:
+        super().resizeEvent(e)
+        self.setMinimumHeight(self.heightForWidth(max(1, self.width())))
 
 
 # == campo com placeholder ====================================================

--- a/scriba/qt/wizard_ui.py
+++ b/scriba/qt/wizard_ui.py
@@ -52,11 +52,13 @@ class WizardWindow(QWidget):
 
         h = QLabel("Atas na língua da sua profissão")
         h.setStyleSheet(f"font-size:{theme.zpt(13)}pt; font-weight:bold;"); root.addWidget(h)
-        sub = QLabel("Descreva seu perfil e o ScribaDev escreve as instruções (prompt.md) que moldam o "
-                     "resumo das suas reuniões — e o vocabulário que guia a transcrição. Você revisa antes.")
-        sub.setProperty("role", "muted"); sub.setWordWrap(True); root.addWidget(sub)
-        warn = QLabel("Ao gerar com IA, os dados deste formulário são enviados ao provedor de IA configurado.")
-        warn.setProperty("role", "warn"); warn.setWordWrap(True); warn.setStyleSheet(f"font-size:{theme.active().font_size_small}pt;")
+        # WrapLabel: no aperto o texto embrulhado não pode ser comido pelo layout —
+        # quem cede é a prévia, que tem scroll próprio
+        sub = widgets.WrapLabel("Descreva seu perfil e o ScribaDev escreve as instruções (prompt.md) que moldam o "
+                                "resumo das suas reuniões — e o vocabulário que guia a transcrição. Você revisa antes.")
+        sub.setProperty("role", "muted"); root.addWidget(sub)
+        warn = widgets.WrapLabel("Ao gerar com IA, os dados deste formulário são enviados ao provedor de IA configurado.")
+        warn.setProperty("role", "warn"); warn.setStyleSheet(f"font-size:{theme.active().font_size_small}pt;")
         root.addWidget(warn)
 
         base_row = QHBoxLayout()
@@ -102,11 +104,10 @@ class WizardWindow(QWidget):
             cl.setSpacing(4)
             ct = QLabel("Novo: apontamento de horas (opcional)")
             ct.setStyleSheet(f"font-weight:bold; color:{t.warn};")
-            cd = QLabel("Reuniões processadas viram sugestões de apontamento (cliente, horários, "
-                        "descrição), com entrada manual e exportação Excel. Ativar cria o banco "
-                        "local timesheet.db; sem ativar, nada roda nem é criado.")
+            cd = widgets.WrapLabel("Reuniões processadas viram sugestões de apontamento (cliente, horários, "
+                                   "descrição), com entrada manual e exportação Excel. Ativar cria o banco "
+                                   "local timesheet.db; sem ativar, nada roda nem é criado.")
             cd.setProperty("role", "muted")
-            cd.setWordWrap(True)
             self._timesheet_opt = widgets.AnimatedCheckBox("Ativar o apontamento de horas ao aplicar")
             cl.addWidget(ct)
             cl.addWidget(cd)

--- a/tests/test_qt_foundation.py
+++ b/tests/test_qt_foundation.py
@@ -77,6 +77,19 @@ class QtWidgetSmokeTests(unittest.TestCase):
         c.setChecked(False); c._anim.stop(); c.set_fill(0.0)
         c.repaint()
 
+    def test_animated_checkbox_nao_come_o_texto(self):
+        """Regressão (texto comido no Log): o texto é pintado à mão a partir de
+        _BOX+_GAP, então o sizeHint precisa cobrir ESSA geometria (o herdado usava o
+        indicador do estilo, mais estreito) e o layout não pode encolher abaixo dela."""
+        from scriba.qt.widgets import AnimatedCheckBox
+
+        for texto in ("auto-atualizar", "Dia", "Hora ≥"):
+            with self.subTest(texto=texto):
+                c = AnimatedCheckBox(texto)
+                need = c._BOX + c._GAP + c.fontMetrics().horizontalAdvance(texto)
+                self.assertGreaterEqual(c.sizeHint().width(), need)
+                self.assertEqual(c.minimumSizeHint(), c.sizeHint())
+
     def test_stepper(self):
         from scriba.qt.widgets import Stepper
 

--- a/tests/test_qt_log_wizard.py
+++ b/tests/test_qt_log_wizard.py
@@ -263,3 +263,25 @@ class WizardTimesheetTests(unittest.TestCase):
             cfg.timesheet, enabled=True)))
         win = WizardWindow()
         self.assertIsNone(win._timesheet_opt)
+
+    def test_janela_apertada_nao_come_o_texto_do_card(self):
+        """Regressão (texto comido, report de usuário): com a janela na altura MÍNIMA,
+        os labels com word-wrap (card do apontamento e cabeçalho) recebem a altura que
+        o texto pede — o aperto vai p/ a prévia (que tem scroll), nunca corta o texto."""
+        from PySide6.QtWidgets import QApplication, QLabel
+
+        from scriba.qt.wizard_ui import WizardWindow
+
+        win = WizardWindow()
+        win.resize(win.minimumWidth(), win.minimumHeight())
+        win.show()
+        self.addCleanup(win.close)
+        QApplication.processEvents()
+        wrapped = [lb for lb in win.findChildren(QLabel)
+                   if lb.wordWrap() and lb.text().startswith(("Reuniões processadas",
+                                                              "Descreva seu perfil",
+                                                              "Ao gerar com IA"))]
+        self.assertEqual(len(wrapped), 3)   # card + subtítulo + aviso de IA presentes
+        for lb in wrapped:
+            with self.subTest(texto=lb.text()[:30]):
+                self.assertGreaterEqual(lb.height(), lb.heightForWidth(lb.width()))


### PR DESCRIPTION
## Problema

Report de usuário (máquina com métricas de fonte mais largas que as do dev):

- **Janela de Log**: rótulos comidos - "auto-atualiza…", "Di…" (Dia), "Hora …".
- **Assistente de perfil**: a descrição do card "Novo: apontamento de horas" cortada no meio da linha.

## Causas (duas, independentes)

1. **`AnimatedCheckBox` media com uma régua e pintava com outra.**
   O texto é pintado à mão a partir de `x = _BOX + _GAP` (27px), mas o `sizeHint` herdado do `QCheckBox` calcula a largura com o indicador do **estilo nativo** (~20px).
   O widget nascia ~7px mais estreito que a pintura e o fim do rótulo era comido - visível ou não conforme a fonte da máquina.
2. **Labels com word-wrap eram espremidos verticalmente** quando a janela aperta: o mínimo de um `QLabel` embrulhado é ~1 linha, e aninhado num `QFrame` (o card) o `heightForWidth` nem chega ao layout externo.

## Correção

- `AnimatedCheckBox.sizeHint` agora cobre a geometria pintada e `minimumSizeHint == sizeHint` (o layout nunca encolhe abaixo do texto). Vale para **todos** os usos (Log, filtros de data/hora, wizards, Configurações).
- Novo `widgets.WrapLabel`: label embrulhado que impõe `minimumHeight = heightForWidth(largura atual)` a cada resize - no aperto quem cede é a prévia (que tem scroll), nunca o texto. Aplicado nos 3 labels do assistente de perfil (subtítulo, aviso de IA, card do apontamento).

## Testes

- Foundation: `sizeHint` do checkbox cobre a pintura para os rótulos reais do Log; `minimumSizeHint == sizeHint`.
- Wizard na altura **mínima**: os 3 labels embrulhados recebem a altura que o texto pede. O teste reproduzia o bug antes do fix (label com 7px onde o texto pedia 54px).
- Smoke visual offscreen (wizard e Log no tamanho mínimo): nenhuma linha cortada.
- Suíte completa: 813 testes OK (12 skipped).
