### PR TITLE
fix(qt): Sobre honesto no app congelado + aviso de claude CLI ausente/deslogada no wizard de perfil

### DIFF
--- a/scriba/qt/settings_ui.py
+++ b/scriba/qt/settings_ui.py
@@ -48,6 +48,32 @@ from . import theme, widgets
 
 log = logging.getLogger("scriba.qt.settings_ui")
 
+
+def _pkg_version(pkg: str, module: str | None = None) -> str | None:
+    """Versão de um pacote p/ a aba Sobre — honesta também no app CONGELADO.
+
+    `importlib.metadata.version()` lê o dist-info, que o bundle PyInstaller NÃO
+    coleta: no instalador ela falha com o pacote PRESENTE e funcionando, e o Sobre
+    acusava "AUSENTE (reinstale o app)" p/ faster-whisper/ctranslate2/pyaudiowpatch
+    (report de usuário). Antes de acusar ausência, confere o MÓDULO via find_spec
+    (sem importar — torch é pesado demais p/ abrir uma aba): achou → "presente"
+    (sem número mesmo, o bundle não tem a metadata). None = ausente de verdade."""
+    try:
+        from importlib.metadata import version
+
+        return version(pkg)
+    except Exception:
+        pass
+    try:
+        import importlib.util as ilu
+
+        if ilu.find_spec(module or pkg) is not None:
+            return "presente"
+    except Exception:
+        pass
+    return None
+
+
 _ARCHIVE = {"Opus (~20 MB/h)": "opus", "FLAC (~110 MB/h)": "flac", "WAV (cru)": "wav"}
 _WHISPER_MODELS = ("tiny", "base", "small", "medium", "large-v3", "large-v3-turbo")
 _WHISPER_DEVICES = {"Automático": "auto", "GPU (CUDA)": "cuda", "CPU": "cpu"}
@@ -868,18 +894,12 @@ class SettingsWindow(QWidget):
     def _about_components(self) -> list:
         import sys
 
-        def ver(pkg):
-            try:
-                from importlib.metadata import version
-
-                return version(pkg)
-            except Exception:
-                return None
+        ver = _pkg_version
 
         def core(label, text, present):
             return (label, text if present else text + " — AUSENTE (reinstale o app)", "ok" if present else "err")
 
-        fw, ct, pa = ver("faster-whisper"), ver("ctranslate2"), ver("pyaudiowpatch")
+        fw, ct, pa = ver("faster-whisper", "faster_whisper"), ver("ctranslate2"), ver("pyaudiowpatch")
         torch_v = ver("torch")
         if sys.platform == "win32":
             audio_row = core("Áudio (WASAPI)", f"pyaudiowpatch {pa or '?'}", bool(pa))
@@ -903,9 +923,18 @@ class SettingsWindow(QWidget):
 
         try:
             present = ilu.find_spec("pyannote.audio") is not None
+        except ModuleNotFoundError:
+            # nem o namespace 'pyannote' existe (find_spec de submódulo LEVANTA em
+            # vez de devolver None): é ausência normal, não "erro ao checar"
+            present = False
         except Exception as e:
             return (f"erro ao checar — {e}", "err")
         if not present:
+            from .. import updates
+
+            if updates.is_frozen_install():
+                return ("não instalada — o download da separação de vozes (torch + pyannote) "
+                        "não foi concluído no 1º uso", "err")
             return ("não instalada — falta o extra [diarization] (pyannote + torch)", "err")
         pa = ver("pyannote.audio") or "?"
         dz = self.app.cfg.diarization

--- a/scriba/qt/wizard_ui.py
+++ b/scriba/qt/wizard_ui.py
@@ -29,6 +29,32 @@ from . import theme, widgets
 log = logging.getLogger("scriba.qt.wizard_ui")
 
 
+def _ai_unavailable_msg() -> str | None:
+    """Aviso IMEDIATO quando o provider de IA nem existe na máquina — o caso típico
+    do instalador: claude CLI ausente (report de usuário: 'Gerar com IA' falhava
+    mudo). Só o which(), sem round-trip de rede: CLI deslogada/endpoint fora
+    aparecem na falha da geração, com dica própria (_ai_fail_msg)."""
+    from .. import config, util
+
+    provider = (config.load().summary.provider or "claude").strip().lower()
+    if provider == "claude" and util.claude_command() is None:
+        return ("IA indisponível: a CLI `claude` não foi encontrada nesta máquina. "
+                'Use "Usar modelo pronto" (funciona offline) — ou instale a Claude CLI, '
+                "faça login e tente de novo.")
+    return None
+
+
+def _ai_fail_msg(generic: str) -> str:
+    """Mensagem de falha da geração por IA: se a causa detectada foi a CLI claude
+    DESLOGADA (ai.last_error), diz isso com a receita; senão, o texto genérico."""
+    from .. import ai
+
+    if ai.last_error == ai.ERR_LOGGED_OUT:
+        return ("Não consegui gerar: a CLI `claude` está deslogada. Rode `claude` no terminal, "
+                'faça /login e tente de novo — ou use "Usar modelo pronto" (offline).')
+    return generic
+
+
 class WizardWindow(QWidget):
     _prompt_ready = Signal(object)   # (prompt, hotwords) | None
     _jargon_ready = Signal(object)   # str | None
@@ -183,6 +209,13 @@ class WizardWindow(QWidget):
     def _generate_ai(self) -> None:
         if self._busy:
             return
+        msg = _ai_unavailable_msg()
+        if msg:
+            self._status.setText(msg)
+            return
+        from .. import ai
+
+        ai.last_error = None   # a falha DESTA geração é que decide a dica (login)
         profile = self._profile()
         self._set_busy(True)
         self._ai_btn.setText("Gerando…")
@@ -197,12 +230,20 @@ class WizardWindow(QWidget):
             prompt, hotwords = outcome
             self._show_result(prompt, hotwords, "gerado por IA e validado")
         else:
-            self._status.setText('Não consegui gerar com IA agora (claude indisponível ou resposta '
-                                 'fora do padrão). O botão "Usar modelo pronto" funciona offline.')
+            self._status.setText(_ai_fail_msg(
+                'Não consegui gerar com IA agora (provedor indisponível ou resposta '
+                'fora do padrão). O botão "Usar modelo pronto" funciona offline.'))
 
     def _suggest_jargon(self) -> None:
         if self._busy:
             return
+        msg = _ai_unavailable_msg()
+        if msg:
+            self._status.setText(msg)
+            return
+        from .. import ai
+
+        ai.last_error = None
         profile = self._profile()
         self._set_busy(True)
         self._jargon_link.setText("Sugerindo…")
@@ -214,8 +255,9 @@ class WizardWindow(QWidget):
         self._set_busy(False)
         self._jargon_link.setText("Sugerir com IA")
         if not suggested:
-            self._status.setText("Não consegui sugerir agora (claude indisponível). Digite alguns termos "
-                                 "que você ouve nas reuniões — ou siga sem: o campo é opcional.")
+            self._status.setText(_ai_fail_msg(
+                "Não consegui sugerir agora (provedor de IA indisponível). Digite alguns termos "
+                "que você ouve nas reuniões — ou siga sem: o campo é opcional."))
             return
         current = [t.strip() for t in self._jargon.toPlainText().split(",") if t.strip()]
         merged = list(current)

--- a/tests/test_qt_log_wizard.py
+++ b/tests/test_qt_log_wizard.py
@@ -205,6 +205,42 @@ class WizardTests(unittest.TestCase):
         win._on_prompt(None)
         self.assertIn("Não consegui gerar", win._status.text())
 
+    def test_gerar_com_ia_avisa_cli_ausente(self):
+        """Report de usuário (instalador sem claude CLI): 'Gerar com IA' avisa NA HORA
+        que a CLI não existe — não falha mudo depois de um minuto de espera."""
+        from unittest import mock
+
+        from scriba.qt.wizard_ui import WizardWindow
+
+        win = WizardWindow()
+        with mock.patch("scriba.util.claude_command", return_value=None):
+            win._generate_ai()
+        self.assertIn("não foi encontrada", win._status.text())
+        self.assertFalse(win._busy)   # nem entrou em "Gerando…"
+
+    def test_sugerir_jargao_avisa_cli_ausente(self):
+        from unittest import mock
+
+        from scriba.qt.wizard_ui import WizardWindow
+
+        win = WizardWindow()
+        with mock.patch("scriba.util.claude_command", return_value=None):
+            win._suggest_jargon()
+        self.assertIn("não foi encontrada", win._status.text())
+        self.assertFalse(win._busy)
+
+    def test_falha_com_cli_deslogada_da_receita_de_login(self):
+        from scriba import ai
+        from scriba.qt.wizard_ui import WizardWindow
+
+        win = WizardWindow()
+        ai.last_error = ai.ERR_LOGGED_OUT
+        self.addCleanup(lambda: setattr(ai, "last_error", None))
+        win._on_prompt(None)
+        self.assertIn("/login", win._status.text())
+        win._on_jargon(None)
+        self.assertIn("/login", win._status.text())
+
     def test_on_jargon_mescla(self):
         from scriba.qt.wizard_ui import WizardWindow
 

--- a/tests/test_qt_settings.py
+++ b/tests/test_qt_settings.py
@@ -290,6 +290,31 @@ class SettingsTests(unittest.TestCase):
         comps = win._about_components()
         self.assertTrue(any(label == "Python" for label, _v, _l in comps))
 
+    def test_pkg_version_honesta_sem_metadata(self):
+        """Report de usuário (instalador): o bundle PyInstaller não traz o dist-info,
+        então metadata ausente com o MÓDULO presente não pode virar 'AUSENTE
+        (reinstale o app)' — cai p/ find_spec e responde 'presente'."""
+        from scriba.qt.settings_ui import _pkg_version
+
+        self.assertEqual(_pkg_version("dist-que-nao-existe", "json"), "presente")
+        self.assertIsNone(_pkg_version("dist-que-nao-existe", "modulo_inexistente_xyz"))
+        self.assertNotIn(_pkg_version("PySide6"), (None, "presente"))  # metadata real
+
+    def test_diar_health_ausencia_nao_e_erro_ao_checar(self):
+        """find_spec('pyannote.audio') LEVANTA ModuleNotFoundError quando nem o
+        namespace 'pyannote' existe — é 'não instalada', nunca 'erro ao checar'."""
+        from unittest import mock
+
+        from scriba.qt.settings_ui import SettingsWindow
+
+        win = SettingsWindow(self._app())
+        with mock.patch("importlib.util.find_spec",
+                        side_effect=ModuleNotFoundError("No module named 'pyannote'")):
+            text, level = win._diar_health(lambda *_a, **_k: None)
+        self.assertEqual(level, "err")
+        self.assertIn("não instalada", text)
+        self.assertNotIn("erro ao checar", text)
+
     def test_show_about_update(self):
         from scriba.qt.settings_ui import SettingsWindow
 


### PR DESCRIPTION
## Problema (reports de usuário do instalador)

Print da aba Sobre numa instalação pelo `setup.exe`:

1. **Falsos "AUSENTE (reinstale o app)"** para faster-whisper, ctranslate2 e pyaudiowpatch - que estão no bundle e funcionando.
   Causa: o PyInstaller não coleta o dist-info, então `importlib.metadata.version()` falha com o pacote presente.
2. **"Diarização: erro ao checar - No module named 'pyannote'"** quando a separação de vozes não foi baixada.
   Causa: `find_spec("pyannote.audio")` LEVANTA `ModuleNotFoundError` quando nem o namespace `pyannote` existe - ausência virava "erro".
3. **"Gerar com IA" do assistente de perfil falhava mudo** sem a claude CLI (o caso típico de quem instala pelo instalador e não tem a CLI).

## Correção

- Novo `_pkg_version(pkg, module)`: metadata primeiro; sem metadata, presença via `find_spec` do módulo (sem importar - torch é pesado demais para abrir uma aba). Sem metadata mas presente → mostra "presente".
- `_diar_health`: `ModuleNotFoundError` = "não instalada" (nunca "erro ao checar"), com mensagem própria por tipo de instalação: congelada ("o download da separação de vozes não foi concluído no 1º uso") vs git (extra `[diarization]`).
- Assistente de perfil: aviso **imediato** quando o provider é claude e a CLI não existe (`_ai_unavailable_msg`, sem esperar o timeout da geração); na falha com CLI deslogada, mensagem com a receita do `/login` (`ai.last_error`). Vale para "Gerar com IA" e "Sugerir com IA".

## Testes

- `_pkg_version`: sem dist-info + módulo presente → "presente"; tudo ausente → None; com metadata → versão real.
- `_diar_health` com `find_spec` levantando `ModuleNotFoundError` → "não instalada", não "erro ao checar".
- Wizard: CLI ausente → aviso na hora (sem entrar em "Gerando…"); `ai.last_error = ERR_LOGGED_OUT` → mensagem com `/login` (prompt e jargão).
- Suíte completa: 818 testes OK (12 skipped).
