### PR TITLE
feat(componentes): retry dos downloads do 1o uso nas Configuracoes + skip explicito de vozes

### DIFF
--- a/scriba/components.py
+++ b/scriba/components.py
@@ -1,0 +1,167 @@
+"""Download/instalação dos componentes pesados — compartilhado wizard/Configurações (#154).
+
+O instalador é enxuto de propósito (#142): modelo Whisper, bibliotecas NVIDIA e
+separação de vozes (torch + pyannote) são baixados sob demanda. A lógica morava
+no wizard de 1º uso (`qt/setup_wizard.py`), que era o ÚNICO caminho — quem pulava
+um download lá ficava sem retry dentro do app. Este módulo extrai o worker,
+UI-free (progresso via callbacks), para o wizard E a seção "Baixar componentes"
+da aba Sobre das Configurações usarem o mesmo código.
+
+Contrato: `run(plan, progress, frac)` nunca levanta — falha vira (False, notas) e
+o app segue funcionando sem o componente (re-tentável).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+from . import sysprobe, updates
+
+log = logging.getLogger("scriba.components")
+
+# pesos (MB estimados) — a barra avança proporcional a eles; o modelo tem % real
+# por bytes (crescimento do cache HF), os pips avançam ao concluir o item
+CUDA_MB = 3000
+VOICES_MB = 3000
+CUDA_PKGS = ["nvidia-cublas-cu12", "nvidia-cudnn-cu12"]
+VOICES_PKGS = ["torch", "pyannote.audio>=4,<5"]
+
+
+def plan_items(model: str | None = None, cuda: bool = False,
+               voices: bool = False) -> list[tuple[str, str, int]]:
+    """[(chave, rótulo de exibição, peso_mb)] do que será baixado. A chave do
+    modelo carrega o nome ('model:small') — `run` não re-parseia rótulo."""
+    items: list[tuple[str, str, int]] = []
+    if model:
+        model_mb = sysprobe.MODEL_DOWNLOAD_MB.get(model, 1500)
+        items.append((f"model:{model}", f"modelo de transcrição {model} (~{model_mb} MB)", model_mb))
+    if cuda:
+        items.append(("cuda", "bibliotecas NVIDIA (cuBLAS/cuDNN, ~3 GB)", CUDA_MB))
+    if voices:
+        items.append(("voices", "separação de vozes (torch + pyannote, ~3 GB)", VOICES_MB))
+    return items
+
+
+def dir_mb(path) -> float:
+    """Tamanho (MB) de uma árvore de diretório; 0 em qualquer erro. Base do % real
+    do modelo: mede o CRESCIMENTO do cache HF durante o download — robusto a versão
+    de lib (nada de depender de tqdm interno do huggingface_hub)."""
+    try:
+        return sum(f.stat().st_size for f in Path(path).rglob("*") if f.is_file()) / 1048576
+    except Exception:
+        return 0.0
+
+
+def model_cache_dir(model: str):
+    """Pasta do cache HF onde o modelo vai cair (existente ou futura). NUNCA levanta:
+    a pasta é só a régua do % real (dir_mb) — errar a régua não pode matar o download
+    (sem huggingface_hub no ambiente, cai no caminho padrão do HF)."""
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+
+        hub = Path(HF_HUB_CACHE)
+    except Exception:
+        hub = Path.home() / ".cache" / "huggingface" / "hub"
+    try:
+        from faster_whisper.utils import _MODELS
+
+        repo = _MODELS.get(model, f"Systran/faster-whisper-{model}")
+    except Exception:
+        repo = f"Systran/faster-whisper-{model}"
+    return hub / ("models--" + repo.replace("/", "--"))
+
+
+def _download_model(model: str, progress) -> tuple[bool, str]:
+    """Baixa/cacheia o modelo Whisper. Devolve (ok, nota-de-erro-ou-'')."""
+    try:
+        from faster_whisper import WhisperModel
+
+        WhisperModel(model, device="cpu", compute_type="int8")  # baixa/cacheia
+        progress(f"modelo {model} pronto.")
+        return True, ""
+    except Exception as e:
+        progress(f"modelo falhou ({e}) - o app baixa na primeira transcrição.")
+        return False, f"modelo: {e}"
+
+
+def _install_extras(extras: list[str], progress) -> tuple[bool, str]:
+    """Instala pacotes pip: congelada → addons in-process; git/venv → pip da venv."""
+    progress("instalando componentes: " + ", ".join(extras) + "…")
+    if updates.is_frozen_install():
+        from . import addons
+
+        return addons.install_to_addons(extras, progress=progress)
+    r = subprocess.run(
+        [updates._pip_interpreter(sys.executable), "-m", "pip", "install", *extras],
+        capture_output=True, text=True, timeout=3600,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0))
+    return r.returncode == 0, (r.stderr or r.stdout or "")[-400:]
+
+
+def run(plan: list[tuple[str, str, int]], progress, frac, poll: bool = True) -> tuple[bool, str]:
+    """Executa o plano com % real na barra: `progress(str)` recebe as linhas de
+    status, `frac(int 0..1000)` o avanço ponderado pelos MB de cada item. `poll`
+    desligado roda sem a thread de medição do cache (testes/inline). Nunca levanta:
+    devolve (ok_geral, notas-de-erro)."""
+    ok_all, notes = True, []
+    total_mb = sum(mb for _k, _l, mb in plan) or 1
+    done_mb = 0.0
+
+    def _p(line: str) -> None:
+        # espelha no scriba.log: relatos de campo ("não baixou nada") chegavam sem
+        # evidência nenhuma — a única saída era o label transiente do wizard
+        log.info("componentes: %s", line)
+        progress(line)
+
+    log.info("componentes: plano = %s", [k for k, _l, _mb in plan] or "(vazio)")
+
+    def _frac(item_done_mb: float) -> None:
+        frac(min(1000, int(1000 * (done_mb + item_done_mb) / total_mb)))
+
+    for key, _label, weight in plan:
+        _frac(0)
+        # resiliência POR ITEM: uma exceção num download não pode matar os demais
+        # (a versão antiga do wizard abortava o plano inteiro — quem tropeçava no
+        # modelo ficava também sem CUDA/vozes, sem nenhuma pista do porquê)
+        try:
+            if key.startswith("model:"):
+                model = key.split(":", 1)[1]
+                _p(f"baixando o modelo {model}…")
+                cache = model_cache_dir(model)
+                base = dir_mb(cache)
+                stop = threading.Event()
+
+                def _poll(cache=cache, base=base, weight=weight, stop=stop):
+                    while not stop.wait(0.5):
+                        _frac(min(weight, max(0.0, dir_mb(cache) - base)))
+
+                if poll:
+                    threading.Thread(target=_poll, daemon=True, name="dl-poll").start()
+                try:
+                    ok, note = _download_model(model, _p)
+                finally:
+                    stop.set()
+            else:
+                extras = CUDA_PKGS if key == "cuda" else VOICES_PKGS
+                ok, note = _install_extras(extras, _p)
+                if ok:
+                    _p("componentes instalados.")
+                    note = ""
+                else:
+                    _p("componentes falharam - dá para tentar de novo depois.")
+                    note = f"componentes: {note}"
+        except Exception as e:  # rede caiu no meio etc.: quem chama nunca trava
+            log.exception("componente %s falhou", key)
+            _p(f"{key} falhou ({e}) - os demais itens continuam.")
+            ok, note = False, f"{key}: {e}"
+        if not ok:
+            ok_all = False
+            if note:
+                notes.append(note)
+        done_mb += weight
+        _frac(0)
+    return ok_all, "; ".join(notes)

--- a/scriba/qt/settings_ui.py
+++ b/scriba/qt/settings_ui.py
@@ -236,6 +236,10 @@ class SettingsWindow(QWidget):
     _about_ready = Signal(object)     # marshaling da checagem de update (thread -> UI)
     _devices_ready = Signal(object)   # marshaling da enumeração de dispositivos (thread -> UI)
     _ts_done = Signal(str)            # marshaling da ativação/desativação do timesheet (#126)
+    _comp_progress = Signal(str)      # linha de status do download de componentes (#154)
+    _comp_frac = Signal(int)          # 0..1000: % real da barra de componentes
+    _comp_done = Signal(bool, str)    # fim do worker de componentes
+    _inline_bg = False                # testes: roda o worker de componentes na própria thread
 
     def __init__(self, app):
         super().__init__()
@@ -867,7 +871,7 @@ class SettingsWindow(QWidget):
         link = QLabel('Repositório: <a href="https://github.com/allanrmartins/ScribaDev">'
                       'github.com/allanrmartins/ScribaDev</a>')
         link.setOpenExternalLinks(True); lay.addWidget(link)
-        lic = QLabel("Licença: Elastic License 2.0 © Allan Martins")
+        lic = QLabel("Licença: MIT © Allan Martins e contribuidores")
         lic.setProperty("role", "muted"); lay.addWidget(lic)
 
         upd = QHBoxLayout()
@@ -887,9 +891,90 @@ class SettingsWindow(QWidget):
             row = QLabel(f"<b>{label}:</b> {value}")
             row.setWordWrap(True); row.setStyleSheet(f"color:{color}; font-size:{theme.zpt(9)}pt;")
             lay.addWidget(row)
+        self._build_components_section(lay)
         lay.addStretch(1)
         scroll.setWidget(inner); outer.addWidget(scroll)
         self._tabs.addTab(page, "Sobre")
+
+    def _build_components_section(self, lay) -> None:
+        """Seção "Baixar componentes" (#154) — só na instalação CONGELADA (setup.exe):
+        o retry do que o wizard de 1º uso pulou/falhou (o instalador é enxuto de
+        propósito). Na instalação git/venv os extras entram via pip, como sempre."""
+        from .. import updates
+
+        if not updates.is_frozen_install():
+            return
+        import sys as _sys
+
+        head = QLabel("Baixar componentes"); head.setStyleSheet("font-weight:bold; margin-top:8px;")
+        lay.addWidget(head)
+        info = widgets.WrapLabel(
+            "O instalador é enxuto: estes itens são baixados sob demanda. Selecione o que "
+            "faltou (ou o que quer re-baixar) — o app continua funcionando durante o download.")
+        info.setProperty("role", "muted")
+        lay.addWidget(info)
+
+        model = getattr(self.app.cfg.whisper, "model", "small")
+        self._comp_model = widgets.AnimatedCheckBox(f"Modelo de transcrição ({model})")
+        self._comp_cuda = widgets.AnimatedCheckBox("Bibliotecas NVIDIA (cuBLAS/cuDNN, ~3 GB)")
+        self._comp_voices = widgets.AnimatedCheckBox("Separação de vozes (torch + pyannote, ~3 GB)")
+        try:  # default: pré-marca o que está faltando de verdade
+            import importlib.util as ilu
+
+            self._comp_voices.setChecked(ilu.find_spec("pyannote") is None)
+        except Exception:
+            pass
+        lay.addWidget(self._comp_model)
+        if _sys.platform == "win32":
+            lay.addWidget(self._comp_cuda)
+        lay.addWidget(self._comp_voices)
+
+        row = QHBoxLayout()
+        self._comp_btn = widgets.ModernButton("Baixar selecionados", self._download_components,
+                                              kind="primary")
+        row.addWidget(self._comp_btn); row.addStretch(1)
+        lay.addLayout(row)
+        self._comp_bar = QProgressBar(); self._comp_bar.setRange(0, 1000); self._comp_bar.setValue(0)
+        self._comp_bar.setVisible(False)
+        lay.addWidget(self._comp_bar)
+        self._comp_status = widgets.WrapLabel(""); self._comp_status.setProperty("role", "muted")
+        lay.addWidget(self._comp_status)
+
+        self._comp_progress.connect(self._comp_status.setText)
+        self._comp_frac.connect(self._comp_bar.setValue)
+        self._comp_done.connect(self._components_done)
+
+    def _download_components(self) -> None:
+        from .. import components
+
+        plan = components.plan_items(
+            model=(getattr(self.app.cfg.whisper, "model", "small")
+                   if self._comp_model.isChecked() else None),
+            cuda=self._comp_cuda.isChecked(),
+            voices=self._comp_voices.isChecked())
+        if not plan:
+            self._comp_status.setText("Nada selecionado.")
+            return
+        self._comp_btn.setEnabled(False)
+        self._comp_bar.setValue(0); self._comp_bar.setVisible(True)
+        self._comp_status.setText("Baixando: " + "; ".join(l for _k, l, _mb in plan) + "…")
+
+        def work():
+            ok, notes = components.run(plan, progress=self._comp_progress.emit,
+                                       frac=self._comp_frac.emit, poll=not self._inline_bg)
+            self._comp_done.emit(ok, notes)
+
+        if self._inline_bg:
+            work()
+        else:
+            threading.Thread(target=work, daemon=True, name="settings-components").start()
+
+    def _components_done(self, ok: bool, notes: str) -> None:
+        self._comp_btn.setEnabled(True)
+        self._comp_bar.setValue(1000)
+        self._comp_status.setText(
+            "Pronto — componentes instalados e já disponíveis (sem reiniciar)." if ok
+            else f"Alguns itens falharam — dá para tentar de novo. Detalhe: {notes}")
 
     def _about_components(self) -> list:
         import sys
@@ -933,8 +1018,8 @@ class SettingsWindow(QWidget):
             from .. import updates
 
             if updates.is_frozen_install():
-                return ("não instalada — o download da separação de vozes (torch + pyannote) "
-                        "não foi concluído no 1º uso", "err")
+                return ("não instalada — baixe logo abaixo, em \"Baixar componentes\" "
+                        "(separação de vozes)", "err")
             return ("não instalada — falta o extra [diarization] (pyannote + torch)", "err")
         pa = ver("pyannote.audio") or "?"
         dz = self.app.cfg.diarization

--- a/scriba/qt/setup_wizard.py
+++ b/scriba/qt/setup_wizard.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import sys
 import threading
 import webbrowser
 
@@ -103,6 +102,7 @@ class SetupWizardWindow(QWidget):
         self.rec: sysprobe.Recommendation | None = None
         self.express = True
         self.skip_voices = False
+        self._voices_skip_warned = False   # aviso de skip explícito (1 clique) — #154
 
         self.setWindowTitle("ScribaDev - Primeiros passos")
         self.setMinimumSize(620, 520)
@@ -390,27 +390,33 @@ class SetupWizardWindow(QWidget):
         self._start_downloads()
 
     def _accept_voices(self) -> None:
-        self.skip_voices = not bool(self._hf_token.text().strip())
+        token = self._hf_token.text().strip()
+        if not token and not self._voices_skip_warned:
+            # skip EXPLÍCITO (#154): sem token, "Ativar e continuar" pulava as vozes
+            # em silêncio e o usuário achava que tinha mandado baixar. Avisa uma vez;
+            # o 2º clique (ou o token colado) segue em frente.
+            self._voices_skip_warned = True
+            t = theme.active()
+            self._voices_hint.setText(
+                "Sem o token, a separação de vozes FICA DE FORA por enquanto — você baixa "
+                "depois em Configurações → Sobre → Baixar componentes. Clique de novo para "
+                "continuar assim, ou cole o token acima.")
+            self._voices_hint.setStyleSheet(f"color:{t.warn};")
+            return
+        self.skip_voices = not bool(token)
         self._start_downloads()
 
     # ------------------------------------------------------------- downloads --
 
-    # pesos (MB estimados) dos itens de download — a barra avança proporcional a
-    # eles; o modelo tem % REAL por bytes (crescimento do cache HF), os pips avançam
-    # ao concluir o item (o pip não expõe bytes de forma estável)
-    _CUDA_MB = 3000
-    _VOICES_MB = 3000
-
     def _plan_items(self) -> list[tuple[str, str, int]]:
-        """[(chave, rótulo de exibição, peso_mb)] do que será baixado."""
-        model = self._selected_model()
-        model_mb = sysprobe.MODEL_DOWNLOAD_MB.get(model, 1500)
-        items = [("model", f"modelo de transcrição {model} (~{model_mb} MB)", model_mb)]
-        if self.rec and self.rec.needs_cuda_libs and updates.is_frozen_install():
-            items.append(("cuda", "bibliotecas NVIDIA (cuBLAS/cuDNN, ~3 GB)", self._CUDA_MB))
-        if not self.skip_voices:
-            items.append(("voices", "separação de vozes (torch + pyannote, ~3 GB)", self._VOICES_MB))
-        return items
+        """[(chave, rótulo de exibição, peso_mb)] — plano do `scriba.components`
+        (worker compartilhado com as Configurações, #154) a partir das escolhas."""
+        from .. import components
+
+        return components.plan_items(
+            model=self._selected_model(),
+            cuda=bool(self.rec and self.rec.needs_cuda_libs and updates.is_frozen_install()),
+            voices=not self.skip_voices)
 
     def _plan(self) -> list[str]:
         return [label for _k, label, _mb in self._plan_items()]
@@ -425,105 +431,16 @@ class SetupWizardWindow(QWidget):
             threading.Thread(target=self._download_worker, daemon=True,
                              name="setup-downloads").start()
 
-    @staticmethod
-    def _dir_mb(path) -> float:
-        """Tamanho (MB) de uma árvore de diretório; 0 em qualquer erro. Base do %
-        real do modelo: mede o CRESCIMENTO do cache HF durante o download — robusto
-        a versão de lib (nada de depender de tqdm interno do huggingface_hub)."""
-        from pathlib import Path
-
-        try:
-            return sum(f.stat().st_size for f in Path(path).rglob("*") if f.is_file()) / 1048576
-        except Exception:
-            return 0.0
-
-    def _model_cache_dir(self, model: str):
-        """Pasta do cache HF onde o modelo vai cair (existente ou futura)."""
-        from pathlib import Path
-
-        from huggingface_hub.constants import HF_HUB_CACHE
-
-        try:
-            from faster_whisper.utils import _MODELS
-
-            repo = _MODELS.get(model, f"Systran/faster-whisper-{model}")
-        except Exception:
-            repo = f"Systran/faster-whisper-{model}"
-        return Path(HF_HUB_CACHE) / ("models--" + repo.replace("/", "--"))
-
     def _download_worker(self) -> None:
-        """Baixa modelo + extras com % REAL na barra: progresso ponderado pelos MB
-        de cada item; dentro do modelo, bytes medidos pelo crescimento do cache HF
-        (thread de poll). Instalação git/venv: pip na venv; congelada: addons
-        in-process. Erro não trava o wizard - vira aviso e o item fica p/ as
-        Configurações."""
-        import subprocess
-        import time
+        """Delegado ao `scriba.components` (#154): o MESMO worker da seção "Baixar
+        componentes" das Configurações — % real ponderado por MB, pip via addons
+        (congelada) ou venv (git). Erro não trava o wizard: vira aviso e o item
+        fica re-tentável nas Configurações."""
+        from .. import components
 
-        ok_all, notes = True, []
-        emit = self._progress.emit
-        plan = self._plan_items()
-        total_mb = sum(mb for _k, _l, mb in plan) or 1
-        done_mb = 0.0
-
-        def frac(item_done_mb: float) -> None:
-            self._progress_frac.emit(min(1000, int(1000 * (done_mb + item_done_mb) / total_mb)))
-
-        try:
-            for key, _label, weight in plan:
-                frac(0)
-                if key == "model":
-                    model = self._selected_model()
-                    emit(f"baixando o modelo {model}…")
-                    cache = self._model_cache_dir(model)
-                    base = self._dir_mb(cache)
-                    stop = threading.Event()
-
-                    def poll():  # % real por bytes enquanto o download roda
-                        while not stop.wait(0.5):
-                            frac(min(weight, max(0.0, self._dir_mb(cache) - base)))
-
-                    poller = threading.Thread(target=poll, daemon=True, name="dl-poll")
-                    if not self._inline_bg:
-                        poller.start()
-                    try:
-                        from faster_whisper import WhisperModel
-
-                        WhisperModel(model, device="cpu", compute_type="int8")  # baixa/cacheia
-                        emit(f"modelo {model} pronto.")
-                    except Exception as e:
-                        ok_all = False
-                        notes.append(f"modelo: {e}")
-                        emit(f"modelo falhou ({e}) - o app baixa na primeira transcrição.")
-                    finally:
-                        stop.set()
-                else:  # cuda | voices: pip (sem bytes estáveis; a barra salta no fim do item)
-                    extras = (["nvidia-cublas-cu12", "nvidia-cudnn-cu12"] if key == "cuda"
-                              else ["torch", "pyannote.audio>=4,<5"])
-                    emit("instalando componentes: " + ", ".join(extras) + "…")
-                    if updates.is_frozen_install():
-                        from .. import addons
-
-                        ok, msg = addons.install_to_addons(extras, progress=emit)
-                    else:
-                        r = subprocess.run(
-                            [updates._pip_interpreter(sys.executable), "-m", "pip",
-                             "install", *extras],
-                            capture_output=True, text=True, timeout=3600,
-                            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0))
-                        ok, msg = r.returncode == 0, (r.stderr or r.stdout or "")[-400:]
-                    if not ok:
-                        ok_all = False
-                        notes.append(f"componentes: {msg}")
-                        emit("componentes falharam - dá para tentar de novo nas Configurações.")
-                    else:
-                        emit("componentes instalados.")
-                done_mb += weight
-                frac(0)
-        except Exception as e:  # rede caiu no meio etc.: wizard nunca trava
-            log.exception("downloads do wizard falharam")
-            ok_all, notes = False, notes + [str(e)]
-        self._done_dl.emit(ok_all, "; ".join(notes))
+        ok, notes = components.run(self._plan_items(), progress=self._progress.emit,
+                                   frac=self._progress_frac.emit, poll=not self._inline_bg)
+        self._done_dl.emit(ok, notes)
 
     def _append_progress(self, line: str) -> None:
         self._dl_log.setText((self._dl_log.text() + "\n" + line).strip())
@@ -532,9 +449,10 @@ class SetupWizardWindow(QWidget):
         self._bar.setValue(1000)
         extra = "" if ok else (
             "<br><br><b>Alguns itens não baixaram</b> - sem problema: o app funciona "
-            f"e você tenta de novo nas Configurações. Detalhe: {notes}")
+            f"e você tenta de novo em Configurações → Sobre → Baixar componentes. Detalhe: {notes}")
         model = self._selected_model()
-        voices = "pulada (ative nas Configurações)" if self.skip_voices else "ativada"
+        voices = ("pulada (baixe depois em Configurações → Sobre)" if self.skip_voices
+                  else "ativada")
         self._ready_box.setText(
             f"Transcrição: <b>{model}</b> · Separação de vozes: <b>{voices}</b>.{extra}")
         self._stack.setCurrentIndex(_P_READY)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,91 @@
+"""Componentes sob demanda (#154): plano, worker compartilhado (wizard/Configurações)
+e medição de cache. Downloads/pips mockados — determinístico, sem rede."""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scriba import components, sysprobe  # noqa: E402
+
+
+class PlanTests(unittest.TestCase):
+    def test_plan_completo_e_pesos(self):
+        items = {k: mb for k, _l, mb in components.plan_items("small", cuda=True, voices=True)}
+        self.assertEqual(items["model:small"], sysprobe.MODEL_DOWNLOAD_MB["small"])
+        self.assertEqual(items["cuda"], components.CUDA_MB)
+        self.assertEqual(items["voices"], components.VOICES_MB)
+
+    def test_plan_vazio_sem_selecao(self):
+        self.assertEqual(components.plan_items(), [])
+
+    def test_plan_parcial(self):
+        self.assertEqual([k for k, _l, _mb in components.plan_items(voices=True)], ["voices"])
+        self.assertEqual([k for k, _l, _mb in components.plan_items("base")], ["model:base"])
+
+
+class RunTests(unittest.TestCase):
+    def test_sucesso_agrega_e_barra_chega_a_1000(self):
+        fracs, lines = [], []
+        with mock.patch.object(components, "_download_model", return_value=(True, "")) as dm, \
+                mock.patch.object(components, "_install_extras", return_value=(True, "")) as ie:
+            ok, notes = components.run(components.plan_items("small", voices=True),
+                                       progress=lines.append, frac=fracs.append, poll=False)
+        self.assertTrue(ok)
+        self.assertEqual(notes, "")
+        self.assertEqual(dm.call_args[0][0], "small")
+        self.assertEqual(ie.call_args[0][0], components.VOICES_PKGS)
+        self.assertEqual(fracs[-1], 1000)
+        self.assertEqual(fracs, sorted(fracs))   # a barra nunca anda para trás
+
+    def test_falha_de_um_item_nao_derruba_o_resto(self):
+        lines = []
+        with mock.patch.object(components, "_download_model", return_value=(False, "modelo: x")), \
+                mock.patch.object(components, "_install_extras", return_value=(True, "")) as ie:
+            ok, notes = components.run(components.plan_items("small", voices=True),
+                                       progress=lines.append, frac=lambda _f: None, poll=False)
+        self.assertFalse(ok)
+        self.assertIn("modelo: x", notes)
+        ie.assert_called_once()                  # as vozes seguiram apesar do modelo falhar
+        self.assertTrue(any("instalados" in l for l in lines))
+
+    def test_excecao_num_item_nao_mata_os_demais(self):
+        """Regressão do worker antigo do wizard: exceção no item do MODELO abortava o
+        plano inteiro — o usuário ficava sem CUDA/vozes sem nenhuma pista do porquê."""
+        with mock.patch.object(components, "_download_model", side_effect=RuntimeError("boom")), \
+                mock.patch.object(components, "_install_extras", return_value=(True, "")) as ie:
+            ok, notes = components.run(components.plan_items("small", voices=True),
+                                       progress=lambda _l: None, frac=lambda _f: None, poll=False)
+        self.assertFalse(ok)
+        self.assertIn("boom", notes)
+        ie.assert_called_once()   # as vozes rodaram mesmo com o modelo explodindo
+
+    def test_excecao_vira_nota_nunca_levanta(self):
+        with mock.patch.object(components, "_install_extras", side_effect=RuntimeError("rede caiu")):
+            ok, notes = components.run(components.plan_items(voices=True),
+                                       progress=lambda _l: None, frac=lambda _f: None, poll=False)
+        self.assertFalse(ok)
+        self.assertIn("rede caiu", notes)
+
+    def test_cuda_usa_os_pacotes_nvidia(self):
+        with mock.patch.object(components, "_install_extras", return_value=(True, "")) as ie:
+            ok, _ = components.run(components.plan_items(cuda=True),
+                                   progress=lambda _l: None, frac=lambda _f: None, poll=False)
+        self.assertTrue(ok)
+        self.assertEqual(ie.call_args[0][0], components.CUDA_PKGS)
+
+
+class DirMbTests(unittest.TestCase):
+    def test_dir_mb_mede_e_degrada(self):
+        d = Path(tempfile.mkdtemp(prefix="scriba_comp_")) / "cache"
+        d.mkdir(parents=True)
+        (d / "blob.bin").write_bytes(b"x" * 1048576)   # 1 MB
+        self.assertAlmostEqual(components.dir_mb(d), 1.0, places=2)
+        self.assertEqual(components.dir_mb(d / "nao-existe"), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_qt_settings.py
+++ b/tests/test_qt_settings.py
@@ -315,6 +315,63 @@ class SettingsTests(unittest.TestCase):
         self.assertIn("não instalada", text)
         self.assertNotIn("erro ao checar", text)
 
+    # -- seção "Baixar componentes" (#154, só instalação congelada) -----------
+    def test_secao_componentes_so_na_instalacao_congelada(self):
+        from unittest import mock
+
+        from scriba.qt.settings_ui import SettingsWindow
+
+        win = SettingsWindow(self._app())
+        self.assertFalse(hasattr(win, "_comp_btn"))      # git/venv: extras via pip, sem seção
+        with mock.patch("scriba.updates.is_frozen_install", return_value=True):
+            win2 = SettingsWindow(self._app())
+        self.assertTrue(hasattr(win2, "_comp_btn"))
+
+    def test_baixar_componentes_monta_o_plano_e_conclui(self):
+        from unittest import mock
+
+        from scriba import components
+        from scriba.qt.settings_ui import SettingsWindow
+
+        with mock.patch("scriba.updates.is_frozen_install", return_value=True):
+            win = SettingsWindow(self._app())
+        win._inline_bg = True
+        win._comp_model.setChecked(False)
+        win._comp_cuda.setChecked(False)
+        win._comp_voices.setChecked(True)
+        with mock.patch.object(components, "run", return_value=(True, "")) as run:
+            win._download_components()
+        self.assertEqual([k for k, _l, _mb in run.call_args[0][0]], ["voices"])
+        self.assertIn("Pronto", win._comp_status.text())
+        self.assertTrue(win._comp_btn.isEnabled())
+
+    def test_baixar_componentes_falha_reabilita_e_avisa(self):
+        from unittest import mock
+
+        from scriba import components
+        from scriba.qt.settings_ui import SettingsWindow
+
+        with mock.patch("scriba.updates.is_frozen_install", return_value=True):
+            win = SettingsWindow(self._app())
+        win._inline_bg = True
+        win._comp_voices.setChecked(True)
+        with mock.patch.object(components, "run", return_value=(False, "componentes: pip 1")):
+            win._download_components()
+        self.assertIn("falharam", win._comp_status.text())
+        self.assertTrue(win._comp_btn.isEnabled())       # re-tentável
+
+    def test_baixar_componentes_nada_selecionado(self):
+        from unittest import mock
+
+        from scriba.qt.settings_ui import SettingsWindow
+
+        with mock.patch("scriba.updates.is_frozen_install", return_value=True):
+            win = SettingsWindow(self._app())
+        for chk in (win._comp_model, win._comp_cuda, win._comp_voices):
+            chk.setChecked(False)
+        win._download_components()
+        self.assertIn("Nada selecionado", win._comp_status.text())
+
     def test_show_about_update(self):
         from scriba.qt.settings_ui import SettingsWindow
 

--- a/tests/test_qt_setup_wizard.py
+++ b/tests/test_qt_setup_wizard.py
@@ -164,23 +164,39 @@ class SetupWizardTests(unittest.TestCase):
         # com vozes: modelo + voices (cuda só em instalação congelada)
         w.skip_voices = False
         items = {k: mb for k, _l, mb in w._plan_items()}
-        self.assertIn("model", items)
+        model_key = f"model:{w._selected_model()}"   # chave composta do components (#154)
+        self.assertIn(model_key, items)
         self.assertIn("voices", items)
         self.assertNotIn("cuda", items)     # não-congelado: sem download de CUDA
-        self.assertEqual(items["model"],
+        self.assertEqual(items[model_key],
                          sysprobe.MODEL_DOWNLOAD_MB[w._selected_model()])
         # pulando as vozes, o item some e o total encolhe
         w.skip_voices = True
         self.assertNotIn("voices", [k for k, _l, _mb in w._plan_items()])
 
-    def test_dir_mb_mede_e_degrada(self):
-        from scriba.qt.setup_wizard import SetupWizardWindow as W
+    # -- skip explícito de vozes (#154) ---------------------------------------
+    def test_continuar_sem_token_avisa_antes_de_pular(self):
+        """'Ativar e continuar' sem token não pode pular as vozes em silêncio:
+        1º clique avisa e fica na página; 2º clique segue sem vozes DE PROPÓSITO."""
+        w = self._win()
+        w._from_machine()
+        idx = w._stack.currentIndex()
+        w._accept_voices()                                   # 1º clique: só o aviso
+        self.assertEqual(w._stack.currentIndex(), idx)       # não saiu da página
+        self.assertIn("FICA DE FORA", w._voices_hint.text())
+        w._accept_voices()                                   # 2º clique: segue sem vozes
+        self.qapp.processEvents()
+        self.assertTrue(w.skip_voices)
+        self.assertEqual(w._stack.currentIndex(), self.swz._P_READY)
 
-        d = self.tmp / "cache"
-        d.mkdir()
-        (d / "blob.bin").write_bytes(b"x" * 1048576)   # 1 MB
-        self.assertAlmostEqual(W._dir_mb(d), 1.0, places=2)
-        self.assertEqual(W._dir_mb(self.tmp / "nao-existe"), 0.0)
+    def test_token_colado_apos_o_aviso_ativa_direto(self):
+        w = self._win()
+        w._from_machine()
+        w._accept_voices()                                   # aviso do skip
+        w._hf_token.setText("hf_tok")
+        w._accept_voices()                                   # com token: ativa normal
+        self.qapp.processEvents()
+        self.assertFalse(w.skip_voices)
 
     def test_barra_avanca_com_progress_frac(self):
         w = self._win()


### PR DESCRIPTION
Closes #154

## Contexto

Dois usuários do instalador reportaram "não baixou as dependências" (prints da aba Sobre com pyannote/torch ausentes).
Três causas combinadas:

1. A página de vozes do wizard pulava o download **silenciosamente** quando o token HF ficava vazio - o usuário achava que tinha mandado baixar.
2. Não havia **nenhum caminho de retry** dentro do app: `install_to_addons` só era chamado pelo wizard de 1º uso, que não roda de novo (a página "Pronto" até prometia "tenta de novo nas Configurações", mas o botão não existia).
3. O worker antigo **abortava o plano inteiro** se um item levantasse exceção - quem tropeçava no modelo ficava também sem CUDA/vozes, sem pista nenhuma.

## O que muda

- **Novo `scriba/components.py`**: worker de downloads UI-free extraído do wizard (plano ponderado por MB, % real do modelo pelo crescimento do cache HF, pip via addons no congelado / venv no git), com:
  - **resiliência por item**: exceção em um download não mata os demais (regressão coberta por teste);
  - progresso **espelhado no scriba.log** - próximos relatos de campo vêm com evidência;
  - `model_cache_dir` que nunca levanta (a régua do % não pode matar o download).
- **Configurações → Sobre → "Baixar componentes"** (só instalação congelada): modelo Whisper atual, bibliotecas NVIDIA e separação de vozes re-baixáveis a qualquer momento, com barra de % real; vozes pré-marcada quando o pyannote falta; instalado = disponível **sem reiniciar** (`addons.bootstrap`).
- **Wizard de 1º uso**: "Ativar e continuar" sem token agora **avisa** - o 1º clique fica na página explicando que as vozes ficam de fora e onde baixar depois; o 2º clique segue sem vozes de propósito. Textos do wizard apontam Configurações → Sobre.
- Aba Sobre: a mensagem de diarização ausente aponta a seção nova; **licença corrigida de Elastic-2.0 para MIT** (desatualizada desde a v1.4.0).

## Testes

- `test_components.py` (novo): plano/pesos, agregação de falhas, resiliência por item (modelo explode → vozes seguem), exceção nunca levanta, pacotes por chave, `dir_mb`.
- Settings: seção só no congelado; plano montado pelas seleções; falha reabilita o botão; "nada selecionado".
- Wizard: skip explícito em 2 cliques (1º avisa e fica na página; 2º segue), token colado após o aviso ativa direto; plano com a chave nova `model:<nome>`.
- Suíte completa: 832 testes OK (12 skipped). Smoke visual offscreen da seção no Sobre.
