### PR TITLE
fix(addons): saida do pip in-process vai p/ logs/pip.log + --only-binary no congelado

### DIFF
--- a/scriba/addons.py
+++ b/scriba/addons.py
@@ -49,11 +49,40 @@ def bootstrap() -> bool:
         return False
 
 
+def pip_log_path() -> Path:
+    """logs/pip.log — TODA a saída do pip in-process vai aqui (ver install_to_addons)."""
+    from . import util
+
+    return util.LOGS_DIR / "pip.log"
+
+
+def _pip_log_tail(n: int = 3) -> str:
+    """Últimas linhas úteis do pip.log p/ a mensagem de erro (prioriza ERROR/Traceback)."""
+    try:
+        lines = [l.strip() for l in pip_log_path().read_text(
+            encoding="utf-8", errors="replace").splitlines() if l.strip()]
+    except OSError:
+        return ""
+    errs = [l for l in lines if "error" in l.lower()]
+    return " | ".join((errs or lines)[-n:])
+
+
 def install_to_addons(packages: list[str], progress=print) -> tuple[bool, str]:
     """Instala `packages` em APP_DIR/addons com o pip IN-PROCESS (o bundle não tem
     `python -m pip`; o pip precisa estar coletado no bundle — ver installer/windows/
     scribadev.spec). Devolve (ok, mensagem). Usado pelo wizard na instalação
-    congelada; na instalação git/venv o wizard usa `sys.executable -m pip` normal."""
+    congelada; na instalação git/venv o wizard usa `sys.executable -m pip` normal.
+
+    Blindagens do caminho congelado (relato de campo: "pip retornou 2" sem NENHUMA
+    pista — rc 2 = crash interno do pip, e o traceback ia p/ um stderr que não
+    existe num app sem console):
+    - stdout/stderr redirecionados p/ logs/pip.log DURANTE o pip: o traceback de um
+      crash e toda a saída ficam gravados; a mensagem de erro aponta o arquivo;
+    - `--only-binary=:all:`: proibido resolver sdist — o build rodaria
+      `sys.executable` (que no bundle é o PRÓPRIO ScribaDev.exe, não um Python);
+    - `--no-input` (sem console p/ perguntar) e barra de progresso desligada."""
+    import contextlib
+
     d = addons_dir()
     d.mkdir(parents=True, exist_ok=True)
     try:
@@ -62,14 +91,26 @@ def install_to_addons(packages: list[str], progress=print) -> tuple[bool, str]:
         return (False, "pip não disponível no bundle — atualize o app (instalador novo) "
                 "ou instale via git (CONTRIBUTING.md).")
     progress(f"instalando em {d}: {', '.join(packages)}")
+    args = ["install", "--target", str(d), "--upgrade", "--only-binary=:all:",
+            "--no-input", "--disable-pip-version-check", "--progress-bar", "off",
+            *packages]
+    plog = pip_log_path()
     try:
-        rc = pip_main(["install", "--target", str(d), "--upgrade", *packages])
-    except SystemExit as e:  # pip às vezes sai via SystemExit
-        rc = int(e.code or 0)
+        plog.parent.mkdir(parents=True, exist_ok=True)
+        with open(plog, "a", encoding="utf-8", errors="replace") as f:
+            f.write(f"\n=== pip {' '.join(args)}\n")
+            with contextlib.redirect_stdout(f), contextlib.redirect_stderr(f):
+                try:
+                    rc = pip_main(args)
+                except SystemExit as e:  # pip às vezes sai via SystemExit
+                    rc = int(e.code or 0)
     except Exception as e:
         log.exception("pip in-process falhou")
-        return (False, f"instalação falhou: {e}")
+        return (False, f"instalação falhou: {e} — detalhes em {plog}")
     if rc != 0:
-        return (False, f"pip retornou {rc} — veja o log")
+        log.warning("pip retornou %d — saída completa em %s", rc, plog)
+        tail = _pip_log_tail()
+        return (False, f"pip retornou {rc} ({tail}) — saída completa em {plog}"
+                if tail else f"pip retornou {rc} — saída completa em {plog}")
     bootstrap()  # entra no sys.path já nesta execução
     return (True, "instalado")

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -1,0 +1,88 @@
+"""Addons da instalação congelada: pip in-process com saída CAPTURADA em logs/pip.log
+(relato de campo: "pip retornou 2" sem pista nenhuma — o traceback ia p/ um stderr
+inexistente no app sem console). pip mockado — determinístico, sem rede."""
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scriba import addons, util  # noqa: E402
+
+
+class InstallToAddonsTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="scriba_addons_"))
+        self._app0, self._logs0 = util.APP_DIR, util.LOGS_DIR
+        util.APP_DIR = self.tmp / "app"
+        util.LOGS_DIR = util.APP_DIR / "logs"
+        self.addCleanup(lambda: shutil.rmtree(self.tmp, ignore_errors=True))
+
+    def tearDown(self):
+        util.APP_DIR, util.LOGS_DIR = self._app0, self._logs0
+
+    def _run(self, fake_pip, packages=("torch",)):
+        with mock.patch("pip._internal.cli.main.main", side_effect=fake_pip):
+            return addons.install_to_addons(list(packages), progress=lambda _l: None)
+
+    def test_saida_do_pip_vai_para_o_pip_log(self):
+        def fake_pip(args):
+            print("Collecting torch")          # stdout do pip → pip.log, não o void
+            print("ERROR: explodiu feio", file=sys.stderr)
+            return 2
+
+        ok, msg = self._run(fake_pip)
+        self.assertFalse(ok)
+        logged = addons.pip_log_path().read_text(encoding="utf-8")
+        self.assertIn("Collecting torch", logged)
+        self.assertIn("explodiu feio", logged)
+        # a mensagem aponta o arquivo e traz a última linha de ERRO
+        self.assertIn(str(addons.pip_log_path()), msg)
+        self.assertIn("explodiu feio", msg)
+
+    def test_streams_nulos_nao_quebram(self):
+        """App windowed (exe sem console): sys.stdout/stderr podem ser None — o
+        redirect p/ o pip.log tem de blindar o print do pip mesmo assim."""
+        def fake_pip(args):
+            print("instalando…")
+            return 0
+
+        out0, err0 = sys.stdout, sys.stderr
+        sys.stdout = sys.stderr = None
+        try:
+            ok, msg = self._run(fake_pip)
+        finally:
+            sys.stdout, sys.stderr = out0, err0
+        self.assertTrue(ok)
+        self.assertIn("instalando…", addons.pip_log_path().read_text(encoding="utf-8"))
+
+    def test_flags_de_blindagem_do_congelado(self):
+        """--only-binary=:all: é obrigatório: um build de sdist rodaria sys.executable,
+        que no bundle é o PRÓPRIO app — não um Python."""
+        seen = {}
+
+        def fake_pip(args):
+            seen["args"] = args
+            return 0
+
+        ok, _ = self._run(fake_pip, packages=("torch", "pyannote.audio>=4,<5"))
+        self.assertTrue(ok)
+        self.assertIn("--only-binary=:all:", seen["args"])
+        self.assertIn("--no-input", seen["args"])
+        self.assertIn("torch", seen["args"])
+
+    def test_systemexit_do_pip_vira_rc(self):
+        def fake_pip(args):
+            raise SystemExit(1)
+
+        ok, msg = self._run(fake_pip)
+        self.assertFalse(ok)
+        self.assertIn("pip retornou 1", msg)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problema (relato de campo na v1.4.1)

Usuário do instalador marcou "Bibliotecas NVIDIA" + "Separação de vozes" na seção nova e recebeu **"pip retornou 2 - veja o log"** - mas não há nada no log para ver.
rc 2 = crash interno do pip (`UNKNOWN_ERROR`), e o traceback vai para o stdout/stderr de um app **sem console** - ou seja, evapora.

Hipóteses testadas e **descartadas** em dev (pip 24/26): streams `None` (rc=0) e duas chamadas in-process no mesmo processo (rc=0/0).
A causa real na máquina do usuário só vai aparecer com o traceback capturado - que é o que este PR garante.

## Correção

- **`logs/pip.log`**: stdout/stderr redirecionados para o arquivo durante o `pip_main` - qualquer saída/crash fica gravado; a mensagem de erro aponta o arquivo e inclui a última linha de erro.
- **`--only-binary=:all:`** no caminho congelado: resolver um sdist dispararia build via `sys.executable` - que no bundle é o **próprio ScribaDev.exe**, não um Python (todas as deps do pyannote.audio 4.0.4 têm wheel, conferido).
- `--no-input` (sem console para prompt), `--disable-pip-version-check`, `--progress-bar off`.

## Testes

`tests/test_addons.py` (novo, pip mockado): saída capturada no pip.log e refletida na mensagem; streams `None` não quebram; flags de blindagem presentes; `SystemExit` vira rc. Suíte completa verde.
