### PR TITLE
feat(suporte): botao Reportar erro no GitHub (zip do log + issue pre-preenchida)

### DIFF
--- a/scriba/diagnostics.py
+++ b/scriba/diagnostics.py
@@ -169,8 +169,10 @@ def export_zip(recordings_dir=None) -> Path:
     desktop = Path.home() / "Desktop"
     dest = (desktop if desktop.is_dir() else Path.home()) / f"scribadev-diagnostico-{stamp}.zip"
     with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as z:
-        # 1) log(s) do app (atual + rotacionados .1/.2/.3)
-        for p in sorted(util.LOGS_DIR.glob("scriba.log*")):
+        # 1) TODOS os logs do app: scriba.log (+ rotacionados), pip.log (downloads de
+        # componentes — sem ele o "pip retornou N" chega sem o traceback), hang.log,
+        # relaunch.log
+        for p in sorted(util.LOGS_DIR.glob("*.log*")):
             try:
                 z.write(p, f"logs/{p.name}")
             except OSError:

--- a/scriba/qt/log_ui.py
+++ b/scriba/qt/log_ui.py
@@ -333,6 +333,20 @@ def show_crash_dialog(app, detail: str) -> None:
             except Exception:
                 log.exception("crash dialog: falha ao exportar diagnóstico")
 
+        def _issue():
+            """Zip do diagnóstico + issue do GitHub pré-preenchida (o corpo pede o
+            arraste do zip, que fica selecionado no gerenciador)."""
+            from .. import support
+
+            try:
+                rec = app.cfg.output.resolved_recordings_dir()
+            except Exception:
+                rec = None
+            try:
+                support.open_report("Erro inesperado durante a execução", detail, rec)
+            except Exception:
+                log.exception("crash dialog: falha ao abrir o reporte de issue")
+
         def _close():
             global _crash_win
             _crash_win = None
@@ -341,7 +355,8 @@ def show_crash_dialog(app, detail: str) -> None:
         bar = QHBoxLayout(); bar.addStretch(1)
         bar.addWidget(widgets.ModernButton("Copiar erro", _copy))
         bar.addWidget(widgets.ModernButton("Abrir log", _open_log))
-        bar.addWidget(widgets.ModernButton("Exportar diagnóstico", _export, kind="primary"))
+        bar.addWidget(widgets.ModernButton("Exportar diagnóstico", _export))
+        bar.addWidget(widgets.ModernButton("Reportar no GitHub", _issue, kind="primary"))
         bar.addWidget(widgets.ModernButton("Fechar", _close))
         lay.addLayout(bar)
 

--- a/scriba/qt/settings_ui.py
+++ b/scriba/qt/settings_ui.py
@@ -932,13 +932,19 @@ class SettingsWindow(QWidget):
         row = QHBoxLayout()
         self._comp_btn = widgets.ModernButton("Baixar selecionados", self._download_components,
                                               kind="primary")
-        row.addWidget(self._comp_btn); row.addStretch(1)
+        row.addWidget(self._comp_btn)
+        # aparece SÓ quando um download falha: zip do diagnóstico + issue pré-preenchida
+        self._comp_report_btn = widgets.ModernButton("Reportar erro no GitHub",
+                                                     self._report_components_error)
+        self._comp_report_btn.setVisible(False)
+        row.addWidget(self._comp_report_btn); row.addStretch(1)
         lay.addLayout(row)
         self._comp_bar = QProgressBar(); self._comp_bar.setRange(0, 1000); self._comp_bar.setValue(0)
         self._comp_bar.setVisible(False)
         lay.addWidget(self._comp_bar)
         self._comp_status = widgets.WrapLabel(""); self._comp_status.setProperty("role", "muted")
         lay.addWidget(self._comp_status)
+        self._comp_last_notes = ""
 
         self._comp_progress.connect(self._comp_status.setText)
         self._comp_frac.connect(self._comp_bar.setValue)
@@ -972,9 +978,28 @@ class SettingsWindow(QWidget):
     def _components_done(self, ok: bool, notes: str) -> None:
         self._comp_btn.setEnabled(True)
         self._comp_bar.setValue(1000)
+        self._comp_last_notes = notes
+        self._comp_report_btn.setVisible(not ok)
         self._comp_status.setText(
             "Pronto — componentes instalados e já disponíveis (sem reiniciar)." if ok
-            else f"Alguns itens falharam — dá para tentar de novo. Detalhe: {notes}")
+            else f"Alguns itens falharam — dá para tentar de novo, ou reporte o erro "
+                 f"(o botão salva o log e abre a issue). Detalhe: {notes}")
+
+    def _report_components_error(self) -> None:
+        """Botão do erro: zip de diagnóstico (com o pip.log) + issue pré-preenchida."""
+        from .. import support
+
+        try:
+            rec = self.app.cfg.output.resolved_recordings_dir()
+        except Exception:
+            rec = None
+        z = support.open_report("Download de componentes falhou (Configurações → Sobre)",
+                                self._comp_last_notes, rec)
+        self._comp_status.setText(
+            f"Abri a página da issue no navegador. Para anexar, arraste o arquivo "
+            f"{z.name} (deixei selecionado no gerenciador de arquivos)." if z else
+            "Abri a página da issue no navegador — não consegui gerar o zip; "
+            "descreva o cenário na issue, por favor.")
 
     def _about_components(self) -> list:
         import sys

--- a/scriba/qt/setup_wizard.py
+++ b/scriba/qt/setup_wizard.py
@@ -103,6 +103,7 @@ class SetupWizardWindow(QWidget):
         self.express = True
         self.skip_voices = False
         self._voices_skip_warned = False   # aviso de skip explícito (1 clique) — #154
+        self._dl_notes = ""                # notas do último download (p/ o Reportar erro)
 
         self.setWindowTitle("ScribaDev - Primeiros passos")
         self.setMinimumSize(620, 520)
@@ -322,9 +323,24 @@ class SetupWizardWindow(QWidget):
         self._ready_box = QLabel("")
         self._ready_box.setWordWrap(True)
         lay.addWidget(self._ready_box)
+        # só aparece se algum download falhou: zip do diagnóstico + issue pré-preenchida
+        self._report_btn = widgets.ModernButton("Reportar erro no GitHub", self._report_dl_error)
+        self._report_btn.setVisible(False)
+        row = QHBoxLayout(); row.addWidget(self._report_btn); row.addStretch(1)
+        lay.addLayout(row)
         lay.addStretch(1)
         self._nav(lay, next_label="Começar a usar", next_cb=self._finish)
         return w
+
+    def _report_dl_error(self) -> None:
+        from .. import support
+
+        z = support.open_report("Download de componentes falhou no wizard de 1º uso",
+                                self._dl_notes)
+        extra = (f"<br><br>Abri a página da issue. Para anexar, arraste o arquivo {z.name} "
+                 "(deixei selecionado no gerenciador de arquivos)." if z else
+                 "<br><br>Abri a página da issue — descreva o cenário, por favor.")
+        self._ready_box.setText(self._ready_box.text() + extra)
 
     # ------------------------------------------------------------ sonda/fluxo --
 
@@ -447,6 +463,8 @@ class SetupWizardWindow(QWidget):
 
     def _downloads_finished(self, ok: bool, notes: str) -> None:
         self._bar.setValue(1000)
+        self._dl_notes = notes
+        self._report_btn.setVisible(not ok)
         extra = "" if ok else (
             "<br><br><b>Alguns itens não baixaram</b> - sem problema: o app funciona "
             f"e você tenta de novo em Configurações → Sobre → Baixar componentes. Detalhe: {notes}")

--- a/scriba/support.py
+++ b/scriba/support.py
@@ -1,0 +1,67 @@
+"""Reportar erro como issue no GitHub — zip de diagnóstico + página pré-preenchida.
+
+Fluxo do botão "Reportar erro no GitHub" (erro de download de componentes, crash):
+gera o zip de diagnóstico (diagnostics.export_zip), SELECIONA o arquivo no
+gerenciador (util.reveal_path) e abre a página de nova issue com título/corpo
+prontos. O GitHub NÃO aceita anexo por URL — por isso o corpo pede o arraste do
+zip, que já está selecionado a um alt-tab de distância.
+
+Privacidade: o corpo lembra o usuário de revisar o zip antes de anexar (o log
+pode citar títulos das reuniões dele). Tudo aqui é best-effort: sem zip, a issue
+abre mesmo assim (só descrever o cenário já ajuda).
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+import webbrowser
+
+from . import __version__, updates, util
+
+log = logging.getLogger("scriba.support")
+
+REPO_ISSUES_NEW = "https://github.com/allanrmartins/ScribaDev/issues/new"
+
+
+def issue_url(title: str, body: str) -> str:
+    """URL de nova issue com título e corpo pré-preenchidos (query string)."""
+    from urllib.parse import urlencode
+
+    return REPO_ISSUES_NEW + "?" + urlencode({"title": title, "body": body})
+
+
+def build_report(context: str, detail: str, recordings_dir=None):
+    """(zip_path | None, url da issue). O zip é best-effort — falhou, a issue sai
+    sem ele; `detail` (ex.: a nota de erro do pip) entra truncado no corpo."""
+    zip_path = None
+    try:
+        from . import diagnostics
+
+        zip_path = diagnostics.export_zip(recordings_dir)
+    except Exception:
+        log.exception("reportar erro: export do diagnóstico falhou (issue sai sem zip)")
+    origem = "instalador" if updates.is_frozen_install() else "git/fonte"
+    anexo = (f"⬇️ **Arraste aqui o arquivo `{zip_path.name}`** — deixei ele selecionado no seu "
+             "gerenciador de arquivos. Antes de anexar, vale uma olhada no conteúdo: o log "
+             "pode citar títulos das suas reuniões."
+             if zip_path else
+             "(o zip de diagnóstico não pôde ser gerado — descreva o cenário, por favor)")
+    body = (f"**O que aconteceu**\n{context}\n\n"
+            f"**Detalhe do erro**\n```\n{(detail or '(sem detalhe)').strip()[:900]}\n```\n\n"
+            f"**Ambiente**\n- ScribaDev v{__version__} ({origem})\n- {platform.platform()}\n\n"
+            f"**Diagnóstico**\n{anexo}\n")
+    return zip_path, issue_url(f"[erro] {context}"[:120], body)
+
+
+def open_report(context: str, detail: str, recordings_dir=None):
+    """Ação do botão: zip + seleção no gerenciador + navegador na issue.
+    Devolve o caminho do zip (ou None) p/ a UI informar onde ficou."""
+    zip_path, url = build_report(context, detail, recordings_dir)
+    if zip_path is not None:
+        try:
+            util.reveal_path(zip_path)
+        except Exception:
+            log.debug("reveal do zip falhou", exc_info=True)
+    webbrowser.open(url)
+    return zip_path

--- a/scriba/util.py
+++ b/scriba/util.py
@@ -224,6 +224,24 @@ def open_path(path) -> None:
     plat.open_path(path)
 
 
+def reveal_path(path) -> None:
+    """Abre o gerenciador de arquivos COM o arquivo já SELECIONADO (win/mac) — o
+    'Reportar erro' deixa o zip pronto p/ arrastar na issue. Fallback: abre a pasta."""
+    import subprocess
+
+    p = Path(path)
+    try:
+        if sys.platform == "win32":
+            subprocess.Popen(["explorer", f"/select,{p}"])
+            return
+        if sys.platform == "darwin":
+            subprocess.Popen(["open", "-R", str(p)])
+            return
+    except Exception:
+        log.debug("reveal_path falhou — abrindo a pasta", exc_info=True)
+    open_path(p.parent)
+
+
 def console_python() -> Path:
     """python de CONSOLE do venv para subprocessos (não o pythonw da GUI).
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -46,6 +46,47 @@ class RedactTests(unittest.TestCase):
         self.assertEqual(dg.redact_config(""), "")
 
 
+class ExportZipTests(unittest.TestCase):
+    """export_zip TEM de levar todos os .log (pip.log incluso — sem ele o 'pip
+    retornou N' do Baixar componentes chega sem o traceback). Home/dirs isolados."""
+
+    def setUp(self):
+        import zipfile
+
+        from scriba import util
+        from unittest import mock
+
+        self.zipfile = zipfile
+        self.tmp = Path(tempfile.mkdtemp(prefix="scriba_diagzip_"))
+        self._saved = (util.APP_DIR, util.LOGS_DIR, util.CONFIG_PATH)
+        util.APP_DIR = self.tmp / "app"
+        util.LOGS_DIR = util.APP_DIR / "logs"
+        util.CONFIG_PATH = self.tmp / "config.toml"
+        util.LOGS_DIR.mkdir(parents=True)
+        util.CONFIG_PATH.write_text("[audio]\n", encoding="utf-8")
+        (util.LOGS_DIR / "scriba.log").write_text("linha\n", encoding="utf-8")
+        (util.LOGS_DIR / "pip.log").write_text("=== pip install\nERROR: x\n", encoding="utf-8")
+        self._home = mock.patch("pathlib.Path.home", return_value=self.tmp / "home")
+        (self.tmp / "home").mkdir()
+        self._home.start()
+        self.addCleanup(self._home.stop)
+        self.addCleanup(lambda: shutil.rmtree(self.tmp, ignore_errors=True))
+
+    def tearDown(self):
+        from scriba import util
+
+        util.APP_DIR, util.LOGS_DIR, util.CONFIG_PATH = self._saved
+
+    def test_zip_inclui_pip_log_e_scriba_log(self):
+        dest = dg.export_zip(None)
+        self.assertTrue(str(dest).endswith(".zip"))
+        with self.zipfile.ZipFile(dest) as z:
+            names = z.namelist()
+        self.assertIn("logs/scriba.log", names)
+        self.assertIn("logs/pip.log", names)
+        self.assertIn("ambiente.txt", names)
+
+
 class ReadTailTests(unittest.TestCase):
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp(prefix="scriba_diag_"))

--- a/tests/test_qt_settings.py
+++ b/tests/test_qt_settings.py
@@ -355,10 +355,27 @@ class SettingsTests(unittest.TestCase):
             win = SettingsWindow(self._app())
         win._inline_bg = True
         win._comp_voices.setChecked(True)
+        self.assertTrue(win._comp_report_btn.isHidden())  # sem erro, sem botão de reporte
         with mock.patch.object(components, "run", return_value=(False, "componentes: pip 1")):
             win._download_components()
         self.assertIn("falharam", win._comp_status.text())
         self.assertTrue(win._comp_btn.isEnabled())       # re-tentável
+        self.assertFalse(win._comp_report_btn.isHidden())  # erro → oferece reportar
+
+    def test_reportar_erro_de_componentes_abre_issue(self):
+        from unittest import mock
+
+        from scriba.qt.settings_ui import SettingsWindow
+
+        with mock.patch("scriba.updates.is_frozen_install", return_value=True):
+            win = SettingsWindow(self._app())
+        win._comp_last_notes = "componentes: pip retornou 2"
+        fake_zip = Path(tempfile.mkdtemp(prefix="scriba_rep_")) / "diag.zip"
+        fake_zip.write_bytes(b"z")
+        with mock.patch("scriba.support.open_report", return_value=fake_zip) as rep:
+            win._report_components_error()
+        self.assertIn("pip retornou 2", rep.call_args[0][1])   # detalhe vai p/ a issue
+        self.assertIn("diag.zip", win._comp_status.text())     # instrução de arraste
 
     def test_baixar_componentes_nada_selecionado(self):
         from unittest import mock

--- a/tests/test_qt_setup_wizard.py
+++ b/tests/test_qt_setup_wizard.py
@@ -174,6 +174,25 @@ class SetupWizardTests(unittest.TestCase):
         w.skip_voices = True
         self.assertNotIn("voices", [k for k, _l, _mb in w._plan_items()])
 
+    def test_falha_de_download_oferece_reportar_no_github(self):
+        from unittest import mock
+
+        w = self._win(no_downloads=False)
+        w._download_worker = lambda: w._done_dl.emit(False, "componentes: pip retornou 2")
+        w._from_machine()
+        w._skip_voices()
+        self.qapp.processEvents()
+        self.assertFalse(w._report_btn.isHidden())         # erro → botão visível
+        with mock.patch("scriba.support.open_report", return_value=None) as rep:
+            w._report_dl_error()
+        self.assertIn("pip retornou 2", rep.call_args[0][1])
+        # sucesso não oferece o botão
+        w2 = self._win()                                   # downloads mock ok
+        w2._from_machine()
+        w2._skip_voices()
+        self.qapp.processEvents()
+        self.assertTrue(w2._report_btn.isHidden())
+
     # -- skip explícito de vozes (#154) ---------------------------------------
     def test_continuar_sem_token_avisa_antes_de_pular(self):
         """'Ativar e continuar' sem token não pode pular as vozes em silêncio:

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -1,0 +1,77 @@
+"""Reportar erro no GitHub (scriba.support): URL pré-preenchida + zip best-effort.
+Tudo mockado — nada de rede/navegador/Explorer nos testes."""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+from urllib.parse import parse_qs, urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scriba import __version__, support  # noqa: E402
+
+
+class IssueUrlTests(unittest.TestCase):
+    def test_url_pre_preenchida(self):
+        url = support.issue_url("titulo x", "corpo com acento é & = fim")
+        self.assertTrue(url.startswith(support.REPO_ISSUES_NEW + "?"))
+        q = parse_qs(urlparse(url).query)
+        self.assertEqual(q["title"], ["titulo x"])
+        self.assertEqual(q["body"], ["corpo com acento é & = fim"])   # round-trip fiel
+
+
+class BuildReportTests(unittest.TestCase):
+    def _q(self, url):
+        return parse_qs(urlparse(url).query)
+
+    def test_com_zip_o_corpo_pede_o_arraste(self):
+        z = Path(tempfile.mkdtemp(prefix="scriba_sup_")) / "scribadev-diagnostico-x.zip"
+        z.write_bytes(b"zip")
+        with mock.patch("scriba.diagnostics.export_zip", return_value=z):
+            zip_path, url = support.build_report("Download falhou", "pip retornou 2")
+        self.assertEqual(zip_path, z)
+        body = self._q(url)["body"][0]
+        self.assertIn(z.name, body)                    # pede o arraste do arquivo certo
+        self.assertIn("pip retornou 2", body)          # detalhe do erro no corpo
+        self.assertIn(f"v{__version__}", body)         # ambiente identificado
+        self.assertIn("títulos das suas reuniões", body)   # aviso de privacidade presente
+        self.assertIn("[erro] Download falhou", self._q(url)["title"][0])
+
+    def test_sem_zip_a_issue_sai_mesmo_assim(self):
+        with mock.patch("scriba.diagnostics.export_zip", side_effect=OSError("disco")):
+            zip_path, url = support.build_report("Download falhou", "x")
+        self.assertIsNone(zip_path)
+        self.assertIn("não pôde ser gerado", self._q(url)["body"][0])
+
+    def test_detalhe_gigante_e_truncado(self):
+        with mock.patch("scriba.diagnostics.export_zip", side_effect=OSError("x")):
+            _z, url = support.build_report("ctx", "L" * 5000)
+        self.assertLess(len(self._q(url)["body"][0]), 2000)
+
+
+class OpenReportTests(unittest.TestCase):
+    def test_abre_navegador_e_seleciona_o_zip(self):
+        z = Path(tempfile.mkdtemp(prefix="scriba_sup_")) / "d.zip"
+        z.write_bytes(b"zip")
+        with mock.patch("scriba.diagnostics.export_zip", return_value=z), \
+                mock.patch("scriba.util.reveal_path") as reveal, \
+                mock.patch("scriba.support.webbrowser.open") as wb:
+            out = support.open_report("ctx", "detalhe")
+        self.assertEqual(out, z)
+        reveal.assert_called_once_with(z)
+        self.assertTrue(wb.call_args[0][0].startswith(support.REPO_ISSUES_NEW))
+
+    def test_sem_zip_ainda_abre_o_navegador(self):
+        with mock.patch("scriba.diagnostics.export_zip", side_effect=OSError("x")), \
+                mock.patch("scriba.util.reveal_path") as reveal, \
+                mock.patch("scriba.support.webbrowser.open") as wb:
+            out = support.open_report("ctx", "d")
+        self.assertIsNone(out)
+        reveal.assert_not_called()
+        wb.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## O que muda

Quando algo dá errado (download de componentes falha, ou o app crasha), o usuário agora tem um botão **"Reportar erro no GitHub"** que faz o trabalho sujo:

1. Gera o **zip de diagnóstico** (agora com TODOS os logs — `pip.log` incluso, que era a peça que faltava para diagnosticar o "pip retornou 2").
2. **Seleciona o zip** no gerenciador de arquivos (`explorer /select` no Windows, `open -R` no macOS).
3. Abre a página de **nova issue já pré-preenchida**: título, o que aconteceu, o detalhe do erro, versão/SO/origem da instalação, e a instrução de arrastar o zip (o GitHub não aceita anexo por URL — o arquivo fica a um alt-tab de distância).

O corpo também lembra o usuário de **revisar o zip antes de anexar** (o log pode citar títulos das reuniões dele).

Onde o botão aparece (só em caso de erro):
- Configurações → Sobre → Baixar componentes (o cenário do report de hoje);
- página final do wizard de 1º uso, quando algum download falhou;
- diálogo de crash ("Reportar no GitHub" virou a ação primária).

## Implementação

- `scriba/support.py` (novo): `build_report` (zip best-effort + URL da issue) e `open_report` (reveal + navegador). Sem zip, a issue abre mesmo assim.
- `util.reveal_path` (novo): seleciona o arquivo no gerenciador; fallback abre a pasta.
- `diagnostics.export_zip`: `scriba.log*` → `*.log*` (pip.log, hang.log, relaunch.log).

## Testes

- `test_support.py`: URL com round-trip fiel de título/corpo, corpo com/sem zip, truncamento de detalhe gigante, navegador e reveal mockados.
- `export_zip` inclui `logs/pip.log`.
- Botão visível SÓ no erro (settings e wizard) e o detalhe do erro chegando na issue.
- Suíte completa verde.
