### PR TITLE
feat(log): botao Reportar na janela de Log + toasts de audio apontam o caminho

### DIFF
--- a/scriba/diagnostics.py
+++ b/scriba/diagnostics.py
@@ -58,6 +58,16 @@ def level_num(level: str) -> int:
     return LEVELS.get(str(level).upper(), 20)  # nível desconhecido ~ INFO
 
 
+def error_tail(text: str, n: int = 3, max_chars: int = 900) -> str:
+    """Últimas `n` entradas de nível ERROR+ do log (cada uma já com o traceback
+    incorporado por parse_entries), p/ o corpo de um reporte de issue. Sem nenhum
+    erro no recorte, cai nas últimas entradas quaisquer (contexto ainda ajuda)."""
+    entries = parse_entries(text)
+    errs = [e for e in entries if level_num(e["level"]) >= level_num("ERROR")]
+    pick = (errs or entries)[-n:]
+    return "\n".join(e["text"] for e in pick)[-max_chars:]
+
+
 def filter_entries(entries, level_min: int = 0, date_br: str = "", time_from: str = "") -> list:
     """Filtra por nível mínimo, dia (DD/MM/AAAA exato) e hora a partir de (HH:MM)."""
     out = []

--- a/scriba/main.py
+++ b/scriba/main.py
@@ -196,7 +196,9 @@ class ScribaApp:
         # buraco no início da call 2. Se Recording() falhar, o try/except cobre.
         if probe and util.run_audio_probe() is None:
             log.error("dispositivos de áudio indisponíveis — gravação não iniciada (%s)", source)
-            self._toast("ScribaDev: áudio indisponível", "Não consegui acessar microfone/loopback agora.")
+            self._toast("ScribaDev: áudio indisponível",
+                        "Não consegui acessar microfone/loopback agora. "
+                        "Detalhes e reporte: janela de Log (bandeja).")
             return
         with self.rec_lock:
             if self.rec is not None or self._rec_starting:
@@ -211,7 +213,8 @@ class ScribaApp:
             rec = Recording(self.cfg)
         except Exception as e:
             log.exception("falha ao iniciar gravação")
-            self._toast("ScribaDev: erro ao iniciar gravação", str(e))
+            self._toast("ScribaDev: erro ao iniciar gravação",
+                        f"{e} — detalhes e reporte na janela de Log (bandeja).")
             return
         finally:
             with self.rec_lock:

--- a/scriba/qt/log_ui.py
+++ b/scriba/qt/log_ui.py
@@ -50,13 +50,26 @@ class LogWindow(QWidget):
         bar = QHBoxLayout()
         t_lbl = QLabel("Log do app"); t_lbl.setStyleSheet(f"font-size:{theme.zpt(13)}pt; font-weight:bold;")
         bar.addWidget(t_lbl); bar.addStretch(1)
-        bar.addWidget(widgets.ModernButton("Copiar", self._copy))
-        bar.addWidget(widgets.ModernButton("Abrir pasta", self._open_folder))
-        # "Diagnóstico" (era "Exportar diagnóstico"): o rótulo longo estourava a barra no
-        # tamanho mínimo (#64 pegou o corte); o tooltip mantém o sentido completo.
-        _exp = widgets.ModernButton("Diagnóstico", self._export, kind="primary")
+        # Copiar/Abrir pasta viram icon-only (mesmo padrão dos botões de busca): a barra
+        # precisa caber no mínimo de 640px com os DOIS botões de texto (#64 guarda o corte)
+        _cp = widgets.ModernButton("", self._copy)
+        _cp.setIcon(theme.qicon("copy"))
+        widgets.add_tooltip(_cp, "Copiar o log")
+        bar.addWidget(_cp)
+        _fo = widgets.ModernButton("", self._open_folder)
+        _fo.setIcon(theme.qicon("folder"))
+        widgets.add_tooltip(_fo, "Abrir a pasta do log")
+        bar.addWidget(_fo)
+        _exp = widgets.ModernButton("Diagnóstico", self._export)
         widgets.add_tooltip(_exp, "Exportar diagnóstico (.zip) para suporte")
         bar.addWidget(_exp)
+        # reporte de 1 clique p/ QUALQUER erro (#157: mic/loopback falham só com um
+        # toast — a janela de Log é o lugar p/ onde todo erro aponta). Rótulo curto
+        # p/ caber no mínimo de 640px (#64); o tooltip carrega o sentido completo.
+        _rep = widgets.ModernButton("Reportar", self._report_issue, kind="primary")
+        widgets.add_tooltip(_rep, "Reportar erro no GitHub: salva o diagnóstico (.zip) e abre "
+                                  "uma issue já preenchida com os últimos erros do log")
+        bar.addWidget(_rep)
         root.addLayout(bar)
 
         row1 = QHBoxLayout()
@@ -266,6 +279,22 @@ class LogWindow(QWidget):
         except Exception as e:
             log.exception("falha ao exportar diagnóstico")
             self._status.setText(f"Falha ao exportar: {e}")
+
+    def _report_issue(self) -> None:
+        """Reporte de 1 clique (#157 e afins): zip do diagnóstico + issue no GitHub
+        pré-preenchida com as últimas entradas de ERRO do log (traceback junto)."""
+        from .. import support
+
+        try:
+            rec = self.app.cfg.output.resolved_recordings_dir()
+        except Exception:
+            rec = None
+        detail = diagnostics.error_tail(diagnostics.read_tail(diagnostics.LOG_FILE, _MAX_LINES))
+        z = support.open_report("Erro em uso (reportado pela janela de Log)", detail, rec)
+        self._status.setText(
+            f"Abri a página da issue. Para anexar, arraste o arquivo {z.name} "
+            "(deixei selecionado no gerenciador de arquivos)." if z else
+            "Abri a página da issue — não consegui gerar o zip; descreva o cenário, por favor.")
 
     def show(self) -> None:  # noqa: A003
         super().show()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -46,6 +46,33 @@ class RedactTests(unittest.TestCase):
         self.assertEqual(dg.redact_config(""), "")
 
 
+class ErrorTailTests(unittest.TestCase):
+    """error_tail: as últimas entradas de ERRO (com traceback) p/ o corpo da issue."""
+
+    _LOG = ("17/08/2026 10:00:00 INFO scriba: subiu\n"
+            "17/08/2026 10:00:01 ERROR scriba: mic falhou\n"
+            "Traceback (most recent call last):\n"
+            "  boom no PortAudio\n"
+            "17/08/2026 10:00:02 INFO scriba: seguindo\n"
+            "17/08/2026 10:00:03 ERROR scriba: loopback falhou\n")
+
+    def test_pega_so_erros_com_traceback_junto(self):
+        out = dg.error_tail(self._LOG)
+        self.assertIn("mic falhou", out)
+        self.assertIn("boom no PortAudio", out)     # traceback incorporado na entrada
+        self.assertIn("loopback falhou", out)
+        self.assertNotIn("seguindo", out)           # INFO fica de fora quando há erro
+
+    def test_sem_erros_cai_nas_ultimas_entradas(self):
+        out = dg.error_tail("17/08/2026 10:00:00 INFO scriba: a\n"
+                            "17/08/2026 10:00:01 INFO scriba: b\n")
+        self.assertIn("b", out)
+
+    def test_trunca_no_limite(self):
+        out = dg.error_tail("17/08/2026 10:00:00 ERROR scriba: " + "x" * 5000, max_chars=200)
+        self.assertLessEqual(len(out), 200)
+
+
 class ExportZipTests(unittest.TestCase):
     """export_zip TEM de levar todos os .log (pip.log incluso — sem ele o 'pip
     retornou N' do Baixar componentes chega sem o traceback). Home/dirs isolados."""

--- a/tests/test_qt_log_wizard.py
+++ b/tests/test_qt_log_wizard.py
@@ -161,6 +161,25 @@ class LogTests(unittest.TestCase):
         win._render(stick_bottom=False)                    # setHtml volta o cursor ao início
         self.assertFalse(win._view.textCursor().atEnd())
 
+    def test_reportar_erro_abre_issue_com_os_ultimos_erros(self):
+        """#157: erro operacional (mic/loopback) só dava toast — a janela de Log agora
+        tem o reporte de 1 clique, com os últimos ERROs do log no corpo da issue."""
+        from unittest import mock
+
+        from scriba import diagnostics
+        from scriba.qt.log_ui import LogWindow
+
+        win = LogWindow(_App())
+        fake_log = ("17/08/2026 10:00:01 ERROR scriba: dispositivos de áudio indisponíveis\n"
+                    "Traceback: boom no PortAudio\n")
+        with mock.patch.object(diagnostics, "read_tail", return_value=fake_log), \
+                mock.patch("scriba.support.open_report", return_value=None) as rep:
+            win._report_issue()
+        detail = rep.call_args[0][1]
+        self.assertIn("dispositivos de áudio indisponíveis", detail)
+        self.assertIn("boom no PortAudio", detail)
+        self.assertIn("issue", win._status.text().lower())
+
     def test_crash_dialog_singleton(self):
         from scriba.qt import log_ui
 


### PR DESCRIPTION
## Contexto (#157)

Erro operacional - como o mic/loopback que não abrem ao iniciar a gravação - só dava um **toast que some**: sem crash, sem botão de reporte, sem caminho.
O usuário ficava com o fluxo manual (Diagnóstico → GitHub → anexar).

## O que muda

- **Botão "Reportar" (primário) na janela de Log**: zip de diagnóstico + issue do GitHub pré-preenchida com as **últimas entradas de ERRO do log** (novo `diagnostics.error_tail`: pega ERROR+ com o traceback incorporado; sem erros no recorte, cai nas últimas entradas). A janela de Log vira o ponto de reporte universal - qualquer erro, mesma saída de 1 clique.
- **Toasts apontam o caminho**: "áudio indisponível" e "erro ao iniciar gravação" agora terminam com "detalhes e reporte na janela de Log (bandeja)".
- **Barra do Log no mínimo de 640px** (o guard #64 pegou o estouro): Copiar/Abrir pasta viraram icon-only com tooltip (mesmo padrão dos botões de busca) e o rótulo é "Reportar" curto, com o tooltip completo.

## Testes

- `error_tail`: só erros (com traceback junto), fallback sem erros, truncamento.
- Botão do Log leva os últimos erros do log para a issue (support mockado).
- Guard de botões cortados verde nos dois tamanhos varridos.
- Suíte completa verde.
