### PR TITLE
fix(gui): shell pendurado nao congela mais a GUI em gravacao

### DIFF
--- a/scriba/main.py
+++ b/scriba/main.py
@@ -99,11 +99,19 @@ class ScribaApp:
     # ------------------------------------------------------------- helpers --
 
     def _toast(self, title: str, body: str = "") -> None:
-        if self.notifier:
+        """Toast SEMPRE em thread própria (#161): a entrega fala com o serviço de
+        notificações por COM (cross-process) — se o serviço estiver pendurado, quem
+        chamou (GUI, detector, worker) segue vivo; no pior caso o toast atrasa/some."""
+        if not self.notifier:
+            return
+
+        def _go() -> None:
             try:
                 self.notifier.info(title, body)
             except Exception:
                 log.exception("toast falhou")
+
+        threading.Thread(target=_go, daemon=True, name="toast").start()
 
     def ui(self, fn) -> None:
         """Agenda um callable para rodar na thread da GUI (drenado pelo UiPump)."""

--- a/scriba/qt/tray.py
+++ b/scriba/qt/tray.py
@@ -21,7 +21,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QActionGroup, QColor, QIcon, QPainter, QPixmap
 from PySide6.QtWidgets import QMenu, QMessageBox, QSystemTrayIcon
 
-from .. import autostart, util
+from .. import autostart, shellprobe, util
 from . import theme
 
 log = logging.getLogger("scriba.qt.tray")
@@ -70,6 +70,9 @@ class Tray:
         self.app = app
         self._tray = QSystemTrayIcon(_icon(False))
         self._tray.setToolTip("ScribaDev — aguardando call do Teams")
+        # #161: sonda do shell no ar desde já — set_recording consulta responsive()
+        self._shell_skip_logged = False
+        shellprobe.ensure_started()
 
         m = QMenu()
         self._menu = m
@@ -206,5 +209,17 @@ class Tray:
         self._tray.hide()
 
     def set_recording(self, recording: bool, title: str, dim: bool = False) -> None:
+        # #161: setIcon/setToolTip = Shell_NotifyIcon = SendMessage SÍNCRONO para o
+        # Explorer. Com o shell pendurado, a GUI congelava aqui (AppHangXProcB1) e o
+        # "não está respondendo" derrubou uma gravação real. A atualização é COSMÉTICA:
+        # shell sem responder → pula (o ícone fica parado uns segundos) e segue vivo.
+        if not shellprobe.responsive():
+            if not self._shell_skip_logged:
+                self._shell_skip_logged = True
+                log.warning("shell sem responder — atualizações da bandeja pausadas até ele voltar (#161)")
+            return
+        if self._shell_skip_logged:
+            self._shell_skip_logged = False
+            log.info("shell voltou a responder — bandeja atualizando de novo")
         self._tray.setIcon(_icon(recording, dim=dim))
         self._tray.setToolTip(title)

--- a/scriba/shellprobe.py
+++ b/scriba/shellprobe.py
@@ -1,0 +1,96 @@
+"""Sonda de responsividade do shell do Windows (#161).
+
+Incidente real (2026-08-18): `Shell_NotifyIcon` — o que o `QSystemTrayIcon.setIcon`
+/`setToolTip` fazem por baixo — é um SendMessage SÍNCRONO para a janela da bandeja
+do Explorer. Com o Explorer pendurado, o pulso do ícone REC (a cada 700 ms durante
+a gravação) congelou a thread da GUI (evento AppHangXProcB1), o app foi fechado no
+"não está respondendo" e uma reunião foi parcialmente perdida.
+
+Este módulo mantém uma daemon-thread que cutuca a janela `Shell_TrayWnd` com
+`SendMessageTimeoutW(WM_NULL, …, SMTO_ABORTIFHUNG, 300 ms)` e publica o resultado.
+Quem faz chamada COSMÉTICA de shell (pulso da bandeja, tooltip) consulta
+`responsive()` antes: shell pendurado → pula a atualização (o ícone congela por
+alguns segundos — irrelevante) em vez de congelar o app.
+
+Fail-open por princípio: sonda indisponível, sem dados frescos ou fora do Windows
+= `True`. A sonda existe para evitar o travamento, nunca para prender a bandeja.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+
+log = logging.getLogger("scriba.shellprobe")
+
+_SMTO_ABORTIFHUNG = 0x0002
+_TIMEOUT_MS = 300     # teto do custo por sonda (na THREAD da sonda, nunca na GUI)
+_INTERVAL_S = 1.0     # cadência da sonda
+_MAX_AGE_S = 5.0      # dado mais velho que isto não vale (fail-open)
+
+_SUPPORTED = sys.platform == "win32"   # separado p/ os testes exercitarem a lógica
+_started = False
+_lock = threading.Lock()
+_ok = True
+_checked = 0.0
+
+
+def _find_tray_window() -> int:
+    import ctypes
+
+    return int(ctypes.windll.user32.FindWindowW("Shell_TrayWnd", None))
+
+
+def _send_null_with_timeout(hwnd: int) -> bool:
+    import ctypes
+
+    out = ctypes.c_ulong()
+    res = ctypes.windll.user32.SendMessageTimeoutW(
+        hwnd, 0, 0, 0, _SMTO_ABORTIFHUNG, _TIMEOUT_MS, ctypes.byref(out))
+    return bool(res)
+
+
+def _probe_once() -> bool:
+    """Uma sonda. Sem janela de bandeja (sessão de CI etc.) = True: não há Explorer
+    p/ pendurar ninguém — e a sonda nunca pode virar o motivo de pular atualização."""
+    hwnd = _find_tray_window()
+    if not hwnd:
+        return True
+    return _send_null_with_timeout(hwnd)
+
+
+def _run() -> None:
+    global _ok, _checked
+    while True:
+        try:
+            ok = _probe_once()
+        except Exception:   # sonda quebrada não pode prender nada
+            log.debug("sonda do shell falhou — assumindo responsivo", exc_info=True)
+            ok = True
+        _ok = ok
+        _checked = time.monotonic()
+        time.sleep(_INTERVAL_S)
+
+
+def ensure_started() -> None:
+    """Sobe a daemon-thread da sonda (idempotente; no-op fora do Windows)."""
+    global _started
+    if not _SUPPORTED:
+        return
+    with _lock:
+        if _started:
+            return
+        _started = True
+        threading.Thread(target=_run, daemon=True, name="shellprobe").start()
+
+
+def responsive(max_age_s: float = _MAX_AGE_S) -> bool:
+    """True = a última sonda viu o shell respondendo (ou não há dado confiável —
+    fail-open). É isto que o chamador consulta antes de uma chamada cosmética."""
+    if not _SUPPORTED or not _started:
+        return True
+    if time.monotonic() - _checked > max_age_s:
+        return True
+    return _ok

--- a/scriba/watchdog.py
+++ b/scriba/watchdog.py
@@ -30,12 +30,15 @@ class GuiWatchdog:
     `beat`/`check` aceitam `now` explícito p/ teste determinístico (default = monotonic).
     """
 
-    def __init__(self, threshold_s: float = 10.0, poll_s: float = 1.0, dump=None):
+    def __init__(self, threshold_s: float = 10.0, poll_s: float = 1.0, dump=None,
+                 early_s: float = 5.0):
         self.threshold_s = float(threshold_s)
         self.poll_s = float(poll_s)
+        self.early_s = float(early_s)
         self._dump = dump if dump is not None else self._dump_stacks
         self._last_beat = time.monotonic()
         self._hung_since: float | None = None   # início do episódio em curso (já despejado)
+        self._early_marked = False   # marcador precoce (#161) já logado neste episódio
         self._stop = threading.Event()
 
     # -- API ------------------------------------------------------------------
@@ -66,6 +69,13 @@ class GuiWatchdog:
         heartbeat volta (senão um travamento longo geraria um dump por segundo)."""
         now = time.monotonic() if now is None else now
         stalled_s = now - self._last_beat
+        # marcador PRECOCE (#161): travamento curto finalizado pelo usuário no "não
+        # está respondendo" morria antes do dump — esta linha no scriba.log é o rastro
+        # mínimo que sobrevive (o incidente de 18/08 ficou sem NENHUM registro nosso)
+        if stalled_s > self.early_s and not self._early_marked:
+            self._early_marked = True
+            log.warning("GUI sem responder há ~%.0fs (marcador precoce; pilhas só em %.0fs)",
+                        stalled_s, self.threshold_s)
         if stalled_s > self.threshold_s:
             if self._hung_since is None:
                 self._hung_since = self._last_beat
@@ -74,10 +84,12 @@ class GuiWatchdog:
                 except Exception:
                     log.exception("watchdog: dump falhou")
                 return True
-        elif self._hung_since is not None:
-            log.warning("GUI voltou a responder após ~%.0fs travada (pilhas em %s)",
-                        now - self._hung_since, self.hang_log_path())
-            self._hung_since = None
+        elif stalled_s <= self.early_s:
+            self._early_marked = False   # GUI viva: rearma o marcador p/ o próximo episódio
+            if self._hung_since is not None:
+                log.warning("GUI voltou a responder após ~%.0fs travada (pilhas em %s)",
+                            now - self._hung_since, self.hang_log_path())
+                self._hung_since = None
         return False
 
     # -- dump -------------------------------------------------------------------

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -38,5 +38,53 @@ class TestNoopNotifier(unittest.TestCase):
             self.n.test()
 
 
+class ToastThreadTests(unittest.TestCase):
+    """#161: o toast fala com o serviço de notificações por COM (cross-process) —
+    a entrega roda SEMPRE em thread própria; quem chamou nunca fica preso."""
+
+    def _app(self, notifier):
+        from scriba.main import ScribaApp
+
+        app = ScribaApp.__new__(ScribaApp)
+        app.notifier = notifier
+        return app
+
+    def test_toast_roda_em_thread_propria(self):
+        import threading
+
+        seen = {}
+        done = threading.Event()
+
+        class _N:
+            def info(self, title, body):
+                seen["thread"] = threading.current_thread().name
+                seen["args"] = (title, body)
+                done.set()
+
+        self._app(_N())._toast("Gravando reunião", "corpo")
+        self.assertTrue(done.wait(5))
+        self.assertEqual(seen["args"], ("Gravando reunião", "corpo"))
+        self.assertNotEqual(seen["thread"], threading.current_thread().name)
+
+    def test_erro_do_notifier_nao_propaga(self):
+        import threading
+
+        tried = threading.Event()
+
+        class _Boom:
+            def info(self, title, body):
+                tried.set()
+                raise RuntimeError("serviço fora")
+
+        self._app(_Boom())._toast("x")          # não pode estourar p/ quem chamou
+        self.assertTrue(tried.wait(5))
+        for t in threading.enumerate():          # a thread do toast morre limpa
+            if t.name == "toast":
+                t.join(5)
+
+    def test_sem_notifier_e_no_op(self):
+        self._app(None)._toast("x", "y")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_qt_tray.py
+++ b/tests/test_qt_tray.py
@@ -54,6 +54,29 @@ class TrayTests(unittest.TestCase):
 
         cls.app = QApplication.instance() or QApplication([])
 
+    def test_set_recording_pula_com_shell_pendurado(self):
+        """#161: Shell_NotifyIcon é SendMessage síncrono p/ o Explorer — com o shell
+        sem responder, o pulso NÃO pode chamar setIcon/setToolTip (congelava a GUI e
+        derrubou uma gravação real); com o shell de volta, atualiza de novo."""
+        from unittest import mock
+
+        from scriba.qt.tray import Tray
+
+        tray = Tray(_FakeApp(recording=True))
+        with mock.patch.object(tray._tray, "setIcon") as si, \
+                mock.patch.object(tray._tray, "setToolTip") as st, \
+                mock.patch("scriba.shellprobe.responsive", return_value=False):
+            tray.set_recording(True, "gravando 0:07", dim=True)
+            tray.set_recording(True, "gravando 0:08", dim=False)
+        si.assert_not_called()
+        st.assert_not_called()
+        with mock.patch.object(tray._tray, "setIcon") as si2, \
+                mock.patch.object(tray._tray, "setToolTip") as st2, \
+                mock.patch("scriba.shellprobe.responsive", return_value=True):
+            tray.set_recording(True, "gravando 0:09")
+        si2.assert_called_once()
+        st2.assert_called_once()
+
     def test_sync_esconde_acoes_fora_de_gravacao(self):
         from scriba.qt.tray import Tray
 

--- a/tests/test_shellprobe.py
+++ b/tests/test_shellprobe.py
@@ -1,0 +1,70 @@
+"""Sonda de responsividade do shell (#161): fail-open por princípio — a sonda evita
+congelar a GUI (Shell_NotifyIcon com Explorer pendurado), nunca prende a bandeja."""
+
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scriba import shellprobe  # noqa: E402
+
+
+class ShellProbeTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = (shellprobe._SUPPORTED, shellprobe._started,
+                       shellprobe._ok, shellprobe._checked)
+
+    def tearDown(self):
+        (shellprobe._SUPPORTED, shellprobe._started,
+         shellprobe._ok, shellprobe._checked) = self._saved
+
+    def test_fail_open_fora_do_windows(self):
+        shellprobe._SUPPORTED = False
+        shellprobe._started = True
+        shellprobe._ok = False
+        self.assertTrue(shellprobe.responsive())
+
+    def test_fail_open_sem_sonda_no_ar(self):
+        shellprobe._SUPPORTED = True
+        shellprobe._started = False
+        shellprobe._ok = False
+        self.assertTrue(shellprobe.responsive())
+
+    def test_dado_fresco_manda(self):
+        shellprobe._SUPPORTED = True
+        shellprobe._started = True
+        shellprobe._checked = time.monotonic()
+        shellprobe._ok = False
+        self.assertFalse(shellprobe.responsive())   # shell pendurado → pula cosmético
+        shellprobe._ok = True
+        self.assertTrue(shellprobe.responsive())
+
+    def test_dado_velho_e_otimista(self):
+        # sonda sem dados frescos (thread morta/processo suspenso) não pode prender
+        shellprobe._SUPPORTED = True
+        shellprobe._started = True
+        shellprobe._ok = False
+        shellprobe._checked = time.monotonic() - 99.0
+        self.assertTrue(shellprobe.responsive())
+
+    def test_probe_sem_janela_de_bandeja_e_true(self):
+        # sessão sem Explorer (CI): não há quem pendurar — e não pode travar o pulso
+        with mock.patch.object(shellprobe, "_find_tray_window", return_value=0), \
+                mock.patch.object(shellprobe, "_send_null_with_timeout") as send:
+            self.assertTrue(shellprobe._probe_once())
+        send.assert_not_called()
+
+    def test_probe_reflete_o_send_timeout(self):
+        with mock.patch.object(shellprobe, "_find_tray_window", return_value=42), \
+                mock.patch.object(shellprobe, "_send_null_with_timeout", return_value=False):
+            self.assertFalse(shellprobe._probe_once())   # timeout = pendurado
+        with mock.patch.object(shellprobe, "_find_tray_window", return_value=42), \
+                mock.patch.object(shellprobe, "_send_null_with_timeout", return_value=True):
+            self.assertTrue(shellprobe._probe_once())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -45,6 +45,27 @@ class GuiWatchdogTests(unittest.TestCase):
         self.assertTrue(wd.check(now=130.0))     # episódio 2: despeja de novo
         self.assertEqual(len(dumps), 2)
 
+    def test_marcador_precoce_antes_do_dump(self):
+        """#161: travamento curto finalizado pelo usuário no "não está respondendo"
+        morria sem NENHUM rastro (o dump só vem no limiar cheio) — a partir de
+        `early_s` fica UMA linha de warning no scriba.log, sem despejar pilhas."""
+        wd, dumps = self._wd()
+        wd.beat(now=100.0)
+        with self.assertLogs("scriba.watchdog", level="WARNING") as cm:
+            self.assertFalse(wd.check(now=107.0))    # 7s: marca, não despeja
+        self.assertIn("marcador precoce", cm.output[0])
+        self.assertEqual(dumps, [])
+        with self.assertNoLogs("scriba.watchdog", level="WARNING"):
+            self.assertFalse(wd.check(now=109.0))    # mesmo episódio: não repete
+        self.assertTrue(wd.check(now=111.0))         # limiar cheio: dump normal
+        # retomada rearma o marcador p/ o próximo episódio
+        wd.beat(now=112.0)
+        wd.check(now=112.5)
+        with self.assertLogs("scriba.watchdog", level="WARNING") as cm2:
+            self.assertFalse(wd.check(now=118.5))    # novo episódio, 6s
+        self.assertIn("marcador precoce", cm2.output[-1])
+        self.assertEqual(len(dumps), 1)
+
     def test_dump_de_falha_nao_derruba_o_monitor(self):
         def boom(_s):
             raise RuntimeError("x")


### PR DESCRIPTION
Closes #161

## Incidente

Durante uma gravação real (2026-08-18), o pulso do ícone REC - a cada 700 ms **na thread da GUI** - bloqueou dentro de `Shell_NotifyIcon`, que é um SendMessage **síncrono** para a janela da bandeja do Explorer.
Com o shell pendurado, a GUI congelou (evento Windows 1002, bucket `AppHangXProcB1`), o app foi finalizado no "não está respondendo" e a reunião foi parcialmente perdida.
Mesma família do #114/#127, num ponto que tinha sobrado.

## Correção (a mesma medicina, três frentes)

1. **`scriba/shellprobe.py` (novo)**: daemon-thread cutuca a `Shell_TrayWnd` com `SendMessageTimeoutW(WM_NULL, SMTO_ABORTIFHUNG, 300 ms)` a cada 1 s e publica o resultado. `responsive()` é **fail-open**: fora do Windows, sem sonda ou sem dado fresco → `True` (a sonda existe para evitar o congelamento, nunca para prender a bandeja).
2. **`Tray.set_recording` consulta a sonda**: shell sem responder → **pula** a atualização (cosmética - o ícone fica parado uns segundos) em vez de congelar a GUI. Log uma vez por episódio na pausa e na retomada.
3. **Toast sempre em thread própria**: a entrega fala com o serviço de notificações por COM (cross-process) - quem chamou (GUI, detector, worker) nunca fica preso.

E no **watchdog**: marcador **precoce** em 5 s (uma linha de warning no `scriba.log`, sem dump) - um travamento curto finalizado pelo usuário deixava **zero** rastro nosso, que foi exatamente o caso do incidente. O dump completo de pilhas segue no limiar de sempre.

## Testes

- Sonda: fail-open (sem suporte/sem sonda/dado velho), dado fresco manda, probe sem janela de bandeja, probe refletindo o timeout.
- Bandeja: `set_recording` não toca `setIcon`/`setToolTip` com o shell pendurado e volta a atualizar na retomada.
- Toast: roda em thread própria com os argumentos certos; exceção do notifier não propaga; sem notifier é no-op.
- Watchdog: marcador precoce uma vez por episódio, sem dump antes do limiar, rearme após retomada.
- Suíte completa verde. Sanity real na máquina do incidente: sonda responde `True` com o Explorer saudável.

**Sem bump de versão** - decisão de acumular para a próxima release.
