### PR TITLE
fix(instalador): download de componentes falhava no app instalado - distlib do pip nao acha recursos sob PyInstaller (#164)

### DIFF
--- a/installer/macos/scribadev-mac.spec
+++ b/installer/macos/scribadev-mac.spec
@@ -28,6 +28,12 @@ _excludes = [
 
 _pip_datas, _pip_binaries, _pip_hidden = collect_all("pip")
 
+# pip como FONTE em disco, não no PYZ (#164, espelho do spec Windows): o distlib
+# vendorizado enumera recursos via finder do loader e não conhece o do PyInstaller
+# — in-process ele morria com "Unable to locate finder for 'pip._vendor.distlib'"
+# ao instalar as wheels, e todo download de componentes falhava ("pip retornou 2").
+_pip_collection_mode = {"pip": "py"}
+
 # mlx (transcrição Metal, #104 M5) — o pacote precisa de TRÊS coletas, e faltando
 # qualquer uma o `import mlx_whisper` morre no app instalado (ficou tudo em CPU):
 #   1. collect_all: os submódulos PUROS que o core.so importa em tempo de execução
@@ -68,6 +74,7 @@ _common = dict(
     hiddenimports=_pip_hidden + _mlx_hidden + _mlxw_hidden,
     excludes=_excludes,
     noarchive=False,
+    module_collection_mode=_pip_collection_mode,
 )
 
 a_cli = Analysis([str(Path(SPECPATH) / "entry_cli.py")], **_common)

--- a/installer/windows/scribadev.spec
+++ b/installer/windows/scribadev.spec
@@ -28,6 +28,15 @@ _excludes = [
 # um exe congelado não tem `python -m pip`.
 _pip_datas, _pip_binaries, _pip_hidden = collect_all("pip")
 
+# ...mas como FONTE em disco, não no PYZ (#164): o distlib vendorizado do pip
+# enumera os próprios recursos via finder do loader (distlib/resources.py) e só
+# conhece FileFinder/zipimport — sob o PyiFrozenImporter ele morre com "Unable
+# to locate finder for 'pip._vendor.distlib'" na fase de instalar as wheels
+# (depois de baixar os GB todos), e TODO download de componentes falhava com
+# "pip retornou 2". Com 'py' o pip inteiro vira .py real em _internal/ e importa
+# pelo FileFinder normal, como um pip de verdade.
+_pip_collection_mode = {"pip": "py"}
+
 # Dados do pacote: `assets` (ícones do app/bandeja) e `qt/icons` (SVGs Fluent da UI).
 # Os SVGs faltavam até a 1.4.3 e o app instalado abria SEM ícone nenhum na UI (a
 # engrenagem da config e cia.) — theme.icon() falha graciosamente e não avisa.
@@ -48,6 +57,7 @@ _common = dict(
     hiddenimports=_pip_hidden,
     excludes=_excludes,
     noarchive=False,
+    module_collection_mode=_pip_collection_mode,
 )
 
 a_cli = Analysis([str(Path(SPECPATH) / "entry_cli.py")], **_common)

--- a/scriba/addons.py
+++ b/scriba/addons.py
@@ -139,6 +139,7 @@ def install_to_addons(packages: list[str], progress=print) -> tuple[bool, str]:
             "--no-input", "--disable-pip-version-check", "--progress-bar", "off",
             *packages]
     plog = pip_log_path()
+    root_handlers = list(logging.getLogger().handlers)
     try:
         plog.parent.mkdir(parents=True, exist_ok=True)
         with open(plog, "a", encoding="utf-8", errors="replace") as f:
@@ -151,6 +152,13 @@ def install_to_addons(packages: list[str], progress=print) -> tuple[bool, str]:
     except Exception as e:
         log.exception("pip in-process falhou")
         return (False, f"instalação falhou: {e} — detalhes em {plog}")
+    finally:
+        # o pip configura o PRÓPRIO logging no root (rich console) e não desfaz:
+        # o handler órfão fica preso ao pip.log já fechado e TODO log do app dali
+        # em diante viraria "--- Logging error ---: I/O operation on closed file"
+        for h in logging.getLogger().handlers[:]:
+            if h not in root_handlers:
+                logging.getLogger().removeHandler(h)
     if rc != 0:
         log.warning("pip retornou %d — saída completa em %s", rc, plog)
         tail = _pip_log_tail()

--- a/scriba/cli.py
+++ b/scriba/cli.py
@@ -127,6 +127,17 @@ def main(argv: list[str] | None = None) -> int:
     p_doc = sub.add_parser("doctor", help="diagnóstico do ambiente")
     p_doc.add_argument("--toast", action="store_true", help="dispara uma notificação de teste")
 
+    p_comp = sub.add_parser(
+        "components",
+        help="baixa/instala os componentes pesados sem abrir a GUI — mesmo fluxo do "
+             "wizard/Configurações → Sobre (retry de campo, #164)")
+    p_comp.add_argument("--model", metavar="NOME", default=None,
+                        help="modelo Whisper a baixar (ex.: small, medium, large-v3)")
+    p_comp.add_argument("--cuda", action="store_true",
+                        help="bibliotecas NVIDIA (cuBLAS/cuDNN, ~3 GB)")
+    p_comp.add_argument("--voices", action="store_true",
+                        help="separação de vozes (torch + pyannote, ~3 GB)")
+
     p_auto = sub.add_parser("autostart", help="liga/desliga o início automático com o Windows")
     p_auto.add_argument("mode", choices=["on", "off"])
 
@@ -200,6 +211,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.cmd == "doctor":
         return cmd_doctor(args)
+    if args.cmd == "components":
+        return cmd_components(args)
     if args.cmd == "detect":
         from .detector import debug_loop
 
@@ -286,6 +299,32 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_timesheet(args)
     parser.error(f"comando desconhecido: {args.cmd}")
     return 2
+
+
+def cmd_components(args) -> int:
+    """`scribadev components`: baixa os componentes pesados pela linha de comando —
+    mesmo worker do wizard/Configurações (#154). Nasceu do #164: o download só
+    existia dentro da GUI e não havia como um usuário em campo re-tentar/diagnosticar
+    por terminal (no app instalado, o pip roda in-process — scriba.addons)."""
+    from . import components
+
+    plan = components.plan_items(model=args.model, cuda=args.cuda, voices=args.voices)
+    if not plan:
+        print("nada a fazer - passe --model NOME, --cuda e/ou --voices (veja --help)")
+        return 2
+    last_pct = -1
+
+    def _frac(f: int) -> None:  # barra da GUI vira % no console, de 10 em 10
+        nonlocal last_pct
+        pct = f // 100 * 10
+        if pct > last_pct:
+            last_pct = pct
+            print(f"  {pct}%", flush=True)
+
+    ok, notes = components.run(plan, progress=print, frac=_frac)
+    if not ok:
+        print(f"falhou: {notes}")
+    return 0 if ok else 1
 
 
 def cmd_split(args) -> int:

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -75,6 +75,23 @@ class InstallToAddonsTests(unittest.TestCase):
         self.assertIn("--no-input", seen["args"])
         self.assertIn("torch", seen["args"])
 
+    def test_remove_handlers_que_o_pip_pendura_no_root(self):
+        """O pip in-process configura o PRÓPRIO logging (rich) no root logger e não
+        desfaz — o handler órfão aponta pro pip.log já fechado e cada log do app
+        depois do download virava '--- Logging error ---: I/O operation on closed
+        file' (visto no E2E do #164)."""
+        import logging
+
+        orfao = logging.NullHandler()
+
+        def fake_pip(args):
+            logging.getLogger().addHandler(orfao)
+            return 0
+
+        ok, _ = self._run(fake_pip)
+        self.assertTrue(ok)
+        self.assertNotIn(orfao, logging.getLogger().handlers)
+
     def test_systemexit_do_pip_vira_rc(self):
         def fake_pip(args):
             raise SystemExit(1)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -78,6 +78,30 @@ class RunTests(unittest.TestCase):
         self.assertEqual(ie.call_args[0][0], components.CUDA_PKGS)
 
 
+class CliComponentsTests(unittest.TestCase):
+    """`scribadev components` (#164): retry dos downloads por terminal, sem GUI."""
+
+    def test_roda_o_plano_selecionado(self):
+        from scriba import cli
+        with mock.patch.object(components, "run", return_value=(True, "")) as r:
+            rc = cli.main(["components", "--voices"])
+        self.assertEqual(rc, 0)
+        self.assertEqual([k for k, _l, _mb in r.call_args[0][0]], ["voices"])
+
+    def test_sem_selecao_e_erro_de_uso(self):
+        from scriba import cli
+        with mock.patch.object(components, "run") as r:
+            rc = cli.main(["components"])
+        self.assertEqual(rc, 2)
+        r.assert_not_called()
+
+    def test_falha_vira_exit_code_1(self):
+        from scriba import cli
+        with mock.patch.object(components, "run", return_value=(False, "pip retornou 2")):
+            rc = cli.main(["components", "--cuda"])
+        self.assertEqual(rc, 1)
+
+
 class DirMbTests(unittest.TestCase):
     def test_dir_mb_mede_e_degrada(self):
         d = Path(tempfile.mkdtemp(prefix="scriba_comp_")) / "cache"


### PR DESCRIPTION
## O problema (#164)

No app instalado (setup.exe/DMG), **todo** download de componentes (Configurações → Sobre e wizard de 1º uso) falhava com `pip retornou 2 (ERROR: Exception:)`.
O `logs/pip.log` do primeiro diagnóstico de campo (obrigado, @dittrichi!) finalmente trouxe o traceback:

```
pip._vendor.distlib.DistlibException: Unable to locate finder for 'pip._vendor.distlib'
```

## Causa raiz

O pip roda **in-process** no bundle PyInstaller (`scriba.addons.install_to_addons`), com os módulos congelados no PYZ.
O `distlib` vendorizado do pip enumera os próprios recursos pelo finder do loader (`distlib/resources.py`), que só conhece `FileFinder`/zipimport - sob o `PyiFrozenImporter` ele levanta a exceção acima na hora de instalar as wheels (depois de baixar os GB todos).
Por isso nunca reproduzimos em dev: instalação git roda o pip num Python normal.

## O fix

- `module_collection_mode={"pip": "py"}` nos dois specs (Windows e macOS): o pip inteiro vai como `.py` real em `_internal/` (fora do PYZ) e importa pelo `FileFinder` normal, como um pip de verdade.
- De quebra, `install_to_addons` agora remove os handlers de logging que o pip pendura no root logger e não desfaz (senão todo log do app depois de um download virava `--- Logging error ---: I/O operation on closed file`).
- Novo subcomando **`scribadev components [--model NOME] [--cuda] [--voices]`**: o download só existia dentro da GUI e não havia como re-tentar/diagnosticar por terminal. Foi também o caminho da validação E2E.

## Validação

- Repro E2E num bundle PyInstaller real ANTES do fix: crash idêntico ao relato de campo.
- DEPOIS do fix, no bundle real do app: `scribadev.exe components --voices` instala torch+pyannote em `APP_DIR/addons` com sucesso (exit 0, sem Logging error), e `doctor` reporta o pip embarcado e a pasta de addons OK.
- Suíte completa: 900 testes verdes (novos testes p/ o subcomando e p/ o handler órfão).

Closes #164
