### PR TITLE
fix(pilula): no mac, gravar nao rouba mais o foco do outro app

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -69,7 +69,15 @@ audio archived as Opus (~20 MB/h) ──► folder renamed with the note's title
 Download from the [Releases page](https://github.com/allanrmartins/ScribaDev/releases) and install — **no Python, no terminal**:
 
 - **Windows**: `ScribaDev-X.Y.Z-setup.exe`. The installer is not code-signed (open source project without a paid certificate), so SmartScreen warns on first run: click **"More info" → "Run anyway"**. Per-user install (no admin prompt).
-- **macOS** (14.2+, Apple Silicon): `ScribaDev-X.Y.Z.dmg`. Drag the app to **Applications** and, on first launch, use **right-click → Open** (same reason: unsigned app). Grant the **Microphone**, **Screen & System Audio Recording** and **Accessibility** permissions when prompted.
+- **macOS** (14.2+, Apple Silicon): `ScribaDev-X.Y.Z.dmg`. Drag the app to **Applications** and, **before the first launch**, clear the quarantine flag your browser puts on the download (same reason as Windows: the app is neither signed nor notarized):
+
+  ```bash
+  xattr -dr com.apple.quarantine /Applications/ScribaDev.app
+  ```
+
+  Only then open the app, and grant the **Microphone**, **Screen & System Audio Recording** and **Accessibility** permissions when prompted.
+
+  > ⚠️ **Do not use right-click → Open any more.** macOS 15+ removed that shortcut and, depending on the XProtect version, launching the app while it is still quarantined leaves it **stuck at startup**: no window appears and, a while later, the system reports the app is not responding. If that already happened, clearing the quarantine flag *afterwards* does not help — macOS caches the block: **delete `/Applications/ScribaDev.app`, copy it from the DMG again, run the command above, and only then open it.**
 
 On first launch, the **first-run wizard** analyzes your machine (GPU, memory, disk) and recommends the best setup:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,15 @@ notas.md ──► exportado para %LOCALAPPDATA%\ScribaDev\Notas\
 Baixe na [página de Releases](https://github.com/allanrmartins/ScribaDev/releases) e instale — **sem Python, sem terminal**:
 
 - **Windows**: `ScribaDev-X.Y.Z-setup.exe`. O instalador não é assinado digitalmente (projeto open source sem certificado pago), então o SmartScreen avisa na primeira execução: clique em **"Mais informações" → "Executar mesmo assim"**. A instalação é por usuário (sem pedir administrador).
-- **macOS** (14.2+, Apple Silicon): `ScribaDev-X.Y.Z.dmg`. Arraste o app para **Applications** e, na primeira abertura, use **clique-direito → Abrir** (mesmo motivo: app não assinado). Conceda as permissões de **Microfone**, **Gravação de Tela e Áudio do Sistema** e **Acessibilidade** quando pedidas.
+- **macOS** (14.2+, Apple Silicon): `ScribaDev-X.Y.Z.dmg`. Arraste o app para **Applications** e, **antes da primeira abertura**, tire a marca de quarentena que o navegador põe no download (mesmo motivo do Windows: app não assinado nem notarizado):
+
+  ```bash
+  xattr -dr com.apple.quarantine /Applications/ScribaDev.app
+  ```
+
+  Só então abra o app, e conceda as permissões de **Microfone**, **Gravação de Tela e Áudio do Sistema** e **Acessibilidade** quando pedidas.
+
+  > ⚠️ **Não use mais o clique-direito → Abrir.** O macOS 15+ tirou esse atalho e, dependendo da versão do XProtect, abrir o app ainda em quarentena o deixa **travado na inicialização**: não aparece janela nenhuma e, um tempo depois, o sistema avisa que o app não está respondendo. Se isso já aconteceu, remover a quarentena *depois* não resolve — o macOS guarda o bloqueio: **apague o `/Applications/ScribaDev.app`, copie de novo do DMG, rode o comando acima e só aí abra.**
 
 Na primeira abertura, o **wizard de primeiro uso** analisa sua máquina (GPU, memória, disco) e recomenda a melhor configuração:
 

--- a/scriba/qt/__init__.py
+++ b/scriba/qt/__init__.py
@@ -7,3 +7,18 @@ tkinter e Qt não convivem no mesmo processo (dois event loops disputando a main
 thread). Só no corte o `main.py` troca o loop do Tk por um QApplication e passa a
 importar estas janelas.
 """
+
+import os
+import sys
+
+# macOS: o QPA cocoa termina TODO `QCocoaWindow::raise()` com
+# `[NSApp activateIgnoringOtherApps:YES]`, isto é, traz o processo INTEIRO para a
+# frente. Isso inclui o raise IMPLÍCITO que o `QWidget::show()` faz em janelas
+# `Qt.Tool`/`Qt.ToolTip` — a pílula de gravação e o seu hint de hover. Resultado:
+# mostrar a pílula roubava o foco de quem estava no navegador durante a call.
+# Desligamos o comportamento globalmente e trazemos o app para a frente
+# EXPLICITAMENTE onde isso é intenção do usuário (`widgets.bring_to_front`, usado
+# pelas janelas que abrem pela bandeja). Precisa valer antes do primeiro raise():
+# a env é lida uma única vez, num `static` dentro do QCocoaWindow::raise().
+if sys.platform == "darwin":
+    os.environ.setdefault("QT_MAC_SET_RAISE_PROCESS", "0")

--- a/scriba/qt/chat_ui.py
+++ b/scriba/qt/chat_ui.py
@@ -132,8 +132,7 @@ class ChatWindow(QWidget):
 
     def show(self) -> None:  # noqa: A003
         super().show()
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         widgets.enable_dark_titlebar(self)
         self._entry.setFocus()
         QTimer.singleShot(0, self._refit_all)   # re-ajusta as bolhas com o viewport já dimensionado

--- a/scriba/qt/log_ui.py
+++ b/scriba/qt/log_ui.py
@@ -298,8 +298,7 @@ class LogWindow(QWidget):
 
     def show(self) -> None:  # noqa: A003
         super().show()
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         widgets.enable_dark_titlebar(self)
         # abre no fim se seguindo ao vivo, MAS não se há busca ativa (o campo persiste
         # entre aberturas - closeEvent só esconde): grudar no fim jogaria o 1º hit p/

--- a/scriba/qt/mac.py
+++ b/scriba/qt/mac.py
@@ -15,13 +15,20 @@ log = logging.getLogger("scriba.qt.mac")
 _objc = ctypes.CDLL(ctypes.util.find_library("objc"))
 _objc.sel_registerName.restype = ctypes.c_void_p
 _objc.sel_registerName.argtypes = [ctypes.c_char_p]
+_objc.objc_getClass.restype = ctypes.c_void_p
+_objc.objc_getClass.argtypes = [ctypes.c_char_p]
 
 # objc_msgSend precisa de protótipo POR ASSINATURA (variádica de verdade não existe
-# no ABI arm64): um p/ retorno-ponteiro sem args, outro p/ void com um c_ulong.
+# no ABI arm64): um p/ retorno-ponteiro sem args, um p/ void com um c_ulong e um
+# p/ void com um ponteiro (mensagens do tipo `orderFront:nil`).
 _send_ptr = ctypes.cast(_objc.objc_msgSend,
                         ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p))
 _send_ulong = ctypes.cast(_objc.objc_msgSend,
                           ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_ulong))
+_send_void_ptr = ctypes.cast(_objc.objc_msgSend,
+                             ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p))
+_send_void_bool = ctypes.cast(_objc.objc_msgSend,
+                              ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_bool))
 
 _NS_WINDOW_SHARING_NONE = 0
 
@@ -41,4 +48,48 @@ def set_window_sharing_none(winid: int) -> bool:
         return True
     except Exception:
         log.exception("setSharingType falhou")
+        return False
+
+
+def order_front_no_activate(winid: int) -> bool:
+    """[[view window] orderFront:nil] — sobe a janela na ordem-Z SEM ativar o app.
+
+    Existe porque o `raise_()` do Qt NÃO serve aqui: o QPA cocoa
+    (QCocoaWindow::raise) termina com `[NSApp activateIgnoringOtherApps:YES]`,
+    isto é, traz o ScribaDev INTEIRO para a frente e rouba o foco de quem estava
+    ativo. A pílula re-assere o topo a cada pulso (600 ms), então durante a
+    gravação o foco voltava para cá o tempo todo e era impossível mexer no
+    navegador/Meet. `orderFront:` só reordena — não ativa.
+    """
+    try:
+        window = _send_ptr(ctypes.c_void_p(winid), _objc.sel_registerName(b"window"))
+        if not window:
+            return False
+        _send_void_ptr(window, _objc.sel_registerName(b"orderFront:"), None)
+        return True
+    except Exception:
+        log.exception("orderFront: falhou")
+        return False
+
+
+def activate_app() -> bool:
+    """[NSApp activateIgnoringOtherApps:YES] — traz o ScribaDev para a frente.
+
+    É o que o Qt fazia SOZINHO em todo `raise_()` (e no raise implícito do
+    `show()` de janelas Tool/ToolTip), e que o `QT_MAC_SET_RAISE_PROCESS=0` de
+    `qt/__init__.py` desligou. Agora só acontece quando é intenção do usuário —
+    abrir uma janela pela bandeja (`widgets.bring_to_front`) — e nunca a reboque
+    da pílula de gravação.
+    """
+    try:
+        cls = _objc.objc_getClass(b"NSApplication")
+        if not cls:
+            return False
+        app = _send_ptr(ctypes.c_void_p(cls), _objc.sel_registerName(b"sharedApplication"))
+        if not app:
+            return False
+        _send_void_bool(app, _objc.sel_registerName(b"activateIgnoringOtherApps:"), True)
+        return True
+    except Exception:
+        log.exception("activateIgnoringOtherApps: falhou")
         return False

--- a/scriba/qt/main_window.py
+++ b/scriba/qt/main_window.py
@@ -1080,8 +1080,7 @@ class MainWindow(QWidget):
 
     def show(self) -> None:  # noqa: A003
         super().show()
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         if not self._titlebar_done:
             self._titlebar_done = True
             widgets.enable_dark_titlebar(self)

--- a/scriba/qt/notes_ui.py
+++ b/scriba/qt/notes_ui.py
@@ -928,10 +928,10 @@ class NotesWindow(QWidget):
         # SÓ UMA conversa por vez (#48) — não confundir perguntas de reuniões diferentes.
         if self._chat_alive():
             if self._chat_key == note_path:
-                self._chat.raise_(); self._chat.activateWindow()   # mesma reunião: traz à frente
+                widgets.bring_to_front(self._chat)   # mesma reunião: traz à frente
                 return
             if not self._confirm_close_chat(self._chat_title or "outra reunião"):
-                self._chat.raise_(); self._chat.activateWindow()   # cancelou: mantém a atual
+                widgets.bring_to_front(self._chat)   # cancelou: mantém a atual
                 return
             self._chat.close()   # confirmou: fecha a anterior antes de abrir a nova
         from .chat_ui import ChatWindow
@@ -1253,8 +1253,7 @@ class NotesWindow(QWidget):
 
     def show(self) -> None:  # noqa: A003
         super().show()
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         if not self._titlebar_done:
             self._titlebar_done = True
             widgets.enable_dark_titlebar(self)
@@ -1603,8 +1602,7 @@ class _ActionItemsWindow(QWidget):
 
     def show(self) -> None:  # noqa: A003
         super().show()
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         widgets.enable_dark_titlebar(self)
 
     def closeEvent(self, event) -> None:

--- a/scriba/qt/overlay.py
+++ b/scriba/qt/overlay.py
@@ -412,9 +412,13 @@ class RecordingPill(QWidget):
 
     def _ensure_visible(self) -> None:
         """Mantém no topo e visível durante a call (um fullscreen/compartilhamento pode
-        roubar o topmost). NÃO mexe na captura (segue oculta no compartilhamento)."""
+        roubar o topmost). NÃO mexe na captura (segue oculta no compartilhamento).
+
+        Sobe SEM ativar o app: isto roda a cada pulso (600 ms) e o `raise_()` do Qt
+        no macOS ativa o processo (ver widgets.raise_without_activation) — era o que
+        roubava o foco do navegador durante a gravação inteira."""
         try:
-            self.raise_()
+            widgets.raise_without_activation(self)
             if not self.isVisible():
                 self.show()
         except RuntimeError:
@@ -433,7 +437,7 @@ class RecordingPill(QWidget):
         self.move(x, y)
         self._shown = True
         super().show()
-        self.raise_()
+        widgets.raise_without_activation(self)   # nunca rouba o foco (ver _ensure_visible)
         widgets.exclude_from_capture(self)  # reaplica (defensivo)
         self._ensure_visible()
 

--- a/scriba/qt/settings_ui.py
+++ b/scriba/qt/settings_ui.py
@@ -1381,8 +1381,7 @@ class SettingsWindow(QWidget):
 
     def show(self) -> None:  # noqa: A003
         super().show()
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         if not self._titlebar_done:
             self._titlebar_done = True
             widgets.enable_dark_titlebar(self)

--- a/scriba/qt/setup_wizard.py
+++ b/scriba/qt/setup_wizard.py
@@ -512,8 +512,7 @@ class SetupWizardWindow(QWidget):
 
     def show(self):
         super().show()
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         if not self._titlebar_done:
             self._titlebar_done = True
             widgets.enable_dark_titlebar(self)

--- a/scriba/qt/speakers_ui.py
+++ b/scriba/qt/speakers_ui.py
@@ -178,8 +178,7 @@ class AskNumSpeakers(QWidget):
     def show(self) -> None:  # noqa: A003
         super().show()
         _center_on_screen(self)
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         widgets.enable_dark_titlebar(self)
         self._entry.setFocus()
         self._entry.selectAll()
@@ -348,8 +347,7 @@ class LabelSpeakersDialog(QWidget):
     def show(self) -> None:  # noqa: A003
         super().show()
         _center_on_screen(self)
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         widgets.enable_dark_titlebar(self)
 
 

--- a/scriba/qt/spike.py
+++ b/scriba/qt/spike.py
@@ -138,8 +138,10 @@ class SpikePill(QWidget):
     def _tick_pulse(self) -> None:
         if not self._paused:
             self._pulse_on = not self._pulse_on
-        # re-assere o topmost (um app fullscreen/compartilhando pode roubá-lo)
-        self.raise_()
+        # re-assere o topmost (um app fullscreen/compartilhando pode roubá-lo) SEM
+        # ativar o app — no macOS o raise_() do Qt rouba o foco (ver
+        # widgets.raise_without_activation)
+        widgets.raise_without_activation(self)
         self.update()
 
     # -- clique + arraste coexistindo (o de-risk real p/ a fase B) -----------

--- a/scriba/qt/timesheet_ui.py
+++ b/scriba/qt/timesheet_ui.py
@@ -132,8 +132,7 @@ class TimesheetWindow(QWidget):
 
     def show(self):
         super().show()
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         if not self._titlebar_done:
             self._titlebar_done = True
             widgets.enable_dark_titlebar(self)

--- a/scriba/qt/widgets.py
+++ b/scriba/qt/widgets.py
@@ -149,6 +149,71 @@ def exclude_from_capture(widget) -> bool:
         return False
 
 
+# == topo sem roubar o foco ===================================================
+
+def raise_without_activation(widget) -> bool:
+    """Sobe a janela na ordem-Z SEM trazer o app para a frente. True se usou o
+    caminho nativo do macOS.
+
+    O `raise_()` do Qt não serve para uma janela que se re-assere sozinha: no QPA
+    cocoa, `QCocoaWindow::raise()` termina em `[NSApp activateIgnoringOtherApps:YES]`.
+    Como a pílula re-assere o topo a cada pulso (600 ms), o ScribaDev roubava o foco
+    de volta durante a gravação inteira: dava para clicar no navegador/Meet só na
+    fresta entre dois pulsos.
+
+    É a segunda camada da defesa: `qt/__init__.py` já desliga a ativação embutida no
+    raise (QT_MAC_SET_RAISE_PROCESS=0, a única saída para o raise IMPLÍCITO do
+    `show()` de janelas Tool/ToolTip); aqui, nas chamadas que são nossas, mandamos
+    `[NSWindow orderFront:]` direto — não dependemos daquela env. Se a ponte falhar,
+    NÃO caímos no `raise_()`: ficar um degrau abaixo no empilhamento é cosmético (a
+    janela já é WindowStaysOnTopHint), roubar o foco não é. Fora do macOS o
+    `raise_()` não ativa o processo e segue valendo.
+    """
+    import sys
+
+    if sys.platform != "darwin":
+        widget.raise_()
+        return False
+    try:
+        from PySide6.QtGui import QGuiApplication
+
+        if QGuiApplication.platformName() != "cocoa":
+            return False   # offscreen (CI): winId() não é NSView — chamar o objc derruba
+        from .mac import order_front_no_activate
+
+        return order_front_no_activate(int(widget.winId()))
+    except Exception:
+        return False
+
+
+def bring_to_front(widget) -> None:
+    """Traz a janela para a frente E dá foco a ela — o que o usuário espera ao abrir
+    uma janela pela bandeja/atalho.
+
+    No macOS isso exige ativar o processo explicitamente: o `raise_()` do Qt fazia
+    isso sozinho, mas `qt/__init__.py` desligou esse efeito colateral
+    (QT_MAC_SET_RAISE_PROCESS=0) justamente porque ele também disparava a reboque
+    do `show()` da pílula e roubava o foco durante a gravação. Aqui a ativação é
+    intencional, então é explícita.
+    """
+    import sys
+
+    widget.raise_()
+    widget.activateWindow()
+    if sys.platform != "darwin":
+        return
+    try:
+        from PySide6.QtGui import QGuiApplication
+
+        if QGuiApplication.platformName() != "cocoa":
+            return
+        from .mac import activate_app
+
+        activate_app()
+    except Exception:
+        pass
+
+
 # == botão ====================================================================
 
 class ModernButton(QPushButton):

--- a/scriba/qt/wizard_ui.py
+++ b/scriba/qt/wizard_ui.py
@@ -322,8 +322,7 @@ class WizardWindow(QWidget):
 
     def show(self) -> None:  # noqa: A003
         super().show()
-        self.raise_()
-        self.activateWindow()
+        widgets.bring_to_front(self)   # macOS: ativa o app explicitamente (ver qt/__init__)
         if not self._titlebar_done:
             self._titlebar_done = True
             widgets.enable_dark_titlebar(self)

--- a/tests/test_qt_overlay.py
+++ b/tests/test_qt_overlay.py
@@ -211,5 +211,45 @@ class PillSmokeTests(unittest.TestCase):
             util.STATE_PATH = orig
 
 
+@unittest.skipUnless(_HAS_PYSIDE, "PySide6 não instalado (extra 'qt')")
+class NaoRoubaFocoTests(unittest.TestCase):
+    """A pílula re-assere o topo a cada pulso (600 ms) — e no macOS o `raise_()` do
+    Qt termina em `[NSApp activateIgnoringOtherApps:YES]`, ou seja, traz o app
+    inteiro para a frente. Isso puxava o foco de volta para o ScribaDev durante a
+    gravação inteira: dava para clicar no navegador/Meet só na fresta entre dois
+    pulsos. NENHUM caminho automático da pílula pode chamar `raise_()`."""
+
+    @classmethod
+    def setUpClass(cls):
+        from PySide6.QtWidgets import QApplication
+
+        cls.app = QApplication.instance() or QApplication([])
+
+    def _pill_sem_raise(self):
+        """Pílula cujo `raise_()` explode: qualquer uso reprova o teste."""
+        from scriba.qt.overlay import RecordingPill
+
+        pill = RecordingPill(
+            on_stop=lambda: None, on_discard=lambda: None, on_record=lambda: None,
+            on_speakers=lambda n: None, on_split=lambda: None,
+        )
+        pill.raise_ = lambda: self.fail("raise_() do Qt ativa o app no macOS e rouba o foco")
+        return pill
+
+    def test_pulso_e_show_nao_chamam_raise(self):
+        from scriba import util
+
+        orig = util.STATE_PATH
+        util.STATE_PATH = Path(tempfile.mkdtemp(prefix="scriba_qt_foco_")) / "state.json"
+        try:
+            pill = self._pill_sem_raise()
+            pill.show()              # show() re-assere o topo
+            pill._tick_pulse()       # o pulso de 600 ms, que é o que batia sem parar
+            pill._ensure_visible()   # e o caminho defensivo do show/estágios
+            pill.hide()
+            pill.destroy()
+        finally:
+            util.STATE_PATH = orig
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_qt_overlay.py
+++ b/tests/test_qt_overlay.py
@@ -217,7 +217,11 @@ class NaoRoubaFocoTests(unittest.TestCase):
     Qt termina em `[NSApp activateIgnoringOtherApps:YES]`, ou seja, traz o app
     inteiro para a frente. Isso puxava o foco de volta para o ScribaDev durante a
     gravação inteira: dava para clicar no navegador/Meet só na fresta entre dois
-    pulsos. NENHUM caminho automático da pílula pode chamar `raise_()`."""
+    pulsos. NENHUM caminho automático da pílula pode chamar `raise_()` no macOS.
+
+    O contrato é do macOS, então o teste finge `sys.platform = "darwin"` — assim
+    ele vale nos três runners. Fora do mac o `raise_()` não ativa o processo e
+    segue sendo o caminho certo (coberto em test_qt_widgets.FocoNoMacTests)."""
 
     @classmethod
     def setUpClass(cls):
@@ -239,9 +243,10 @@ class NaoRoubaFocoTests(unittest.TestCase):
     def test_pulso_e_show_nao_chamam_raise(self):
         from scriba import util
 
-        orig = util.STATE_PATH
+        orig_state, orig_plat = util.STATE_PATH, sys.platform
         util.STATE_PATH = Path(tempfile.mkdtemp(prefix="scriba_qt_foco_")) / "state.json"
         try:
+            sys.platform = "darwin"   # o contrato que se testa aqui é o do mac
             pill = self._pill_sem_raise()
             pill.show()              # show() re-assere o topo
             pill._tick_pulse()       # o pulso de 600 ms, que é o que batia sem parar
@@ -249,7 +254,8 @@ class NaoRoubaFocoTests(unittest.TestCase):
             pill.hide()
             pill.destroy()
         finally:
-            util.STATE_PATH = orig
+            sys.platform = orig_plat
+            util.STATE_PATH = orig_state
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_qt_widgets.py
+++ b/tests/test_qt_widgets.py
@@ -99,5 +99,98 @@ class SplitterPersistTests(unittest.TestCase):
         self.assertLessEqual(s.sizes()[0], 360)
 
 
+@unittest.skipUnless(_HAS_PYSIDE, "PySide6 não instalado (extra 'qt')")
+class FocoNoMacTests(unittest.TestCase):
+    """No QPA cocoa, `QCocoaWindow::raise()` termina em
+    `[NSApp activateIgnoringOtherApps:YES]` — traz o processo INTEIRO para a frente.
+    Como a pílula re-assere o topo a cada pulso (600 ms) e o `QWidget::show()` de
+    janelas Qt.Tool/Qt.ToolTip dispara um raise implícito, gravar uma reunião roubava
+    o foco do navegador o tempo todo. Aqui: a env que desliga o efeito colateral e os
+    dois helpers que dividem "subir" de "ativar"."""
+
+    @classmethod
+    def setUpClass(cls):
+        from PySide6.QtWidgets import QApplication
+
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_env_desliga_a_ativacao_implicita_do_qt_no_mac(self):
+        """`import scriba.qt` precisa setar a env ANTES de qualquer QApplication —
+        o Qt lê o valor uma única vez, num `static` dentro do raise()."""
+        import subprocess
+
+        code = (
+            "import sys, os;"
+            "sys.platform = 'darwin';"
+            "os.environ.pop('QT_MAC_SET_RAISE_PROCESS', None);"
+            "import scriba.qt;"
+            "print(os.environ.get('QT_MAC_SET_RAISE_PROCESS'))"
+        )
+        raiz = str(Path(__file__).resolve().parent.parent)
+        out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, cwd=raiz)
+        self.assertEqual(out.stdout.strip(), "0", out.stderr)
+
+    def test_raise_sem_ativacao_no_darwin_nunca_cai_no_raise_do_qt(self):
+        """Se a ponte Cocoa falhar (aqui: QPA offscreen), o helper devolve False e NÃO
+        chama `raise_()`. Ficar um degrau abaixo no empilhamento é cosmético — a pílula
+        já é WindowStaysOnTopHint; roubar o foco não é."""
+        from scriba.qt import widgets
+
+        chamou = []
+
+        class FakeWidget:
+            def raise_(self):
+                chamou.append(True)
+
+            def winId(self):
+                return 0
+
+        plat = sys.platform
+        try:
+            sys.platform = "darwin"
+            self.assertFalse(widgets.raise_without_activation(FakeWidget()))
+        finally:
+            sys.platform = plat
+        self.assertEqual(chamou, [])
+
+    def test_raise_sem_ativacao_fora_do_darwin_usa_o_raise_normal(self):
+        """No Windows/Linux o `raise_()` não ativa o processo — segue valendo."""
+        from scriba.qt import widgets
+
+        chamou = []
+
+        class FakeWidget:
+            def raise_(self):
+                chamou.append(True)
+
+        plat = sys.platform
+        try:
+            sys.platform = "win32"
+            self.assertFalse(widgets.raise_without_activation(FakeWidget()))
+        finally:
+            sys.platform = plat
+        self.assertEqual(chamou, [True])
+
+    def test_bring_to_front_continua_levantando_e_focando(self):
+        """A contrapartida: janela aberta pela bandeja AINDA vem para a frente com
+        foco (no mac, com ativação explícita do processo)."""
+        from scriba.qt import widgets
+
+        chamou = []
+
+        class FakeWidget:
+            def raise_(self):
+                chamou.append("raise")
+
+            def activateWindow(self):
+                chamou.append("activate")
+
+            def winId(self):
+                return 0
+
+        widgets.bring_to_front(FakeWidget())
+        self.assertEqual(chamou, ["raise", "activate"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Com a gravacao em andamento, clicar em qualquer outra janela devolvia o foco para o ScribaDev em menos de um segundo: dava para mexer no Meet/Teams do navegador so na fresta entre dois pulsos da pilula. So aparece no macOS, e o motivo esta no QPA cocoa do Qt.

QCocoaWindow::raise() nao apenas reordena a janela - ele termina em [NSApp activateIgnoringOtherApps:YES], que traz o PROCESSO inteiro para a frente. Dois caminhos batiam nisso:

- RecordingPill._tick_pulse roda a cada 600 ms e chamava raise_() para re-asserir o topmost (overlay.py). Sao ~100 ativacoes por minuto - o sintoma reportado.
- o proprio QWidget::show() dispara um raise IMPLICITO em janelas Qt.Tool e Qt.ToolTip, ou seja, a pilula e o seu hint de hover. Medido: Qt.Window nao dispara, WA_ShowWithoutActivating nao evita, e um show() repetido numa janela ja visivel nao re-dispara.

O fix tem duas camadas. A env QT_MAC_SET_RAISE_PROCESS=0, setada em qt/__init__.py antes de qualquer QApplication (o Qt le o valor uma unica vez, num static dentro do raise), e a unica saida para o raise implicito do show(). Nas chamadas que sao nossas - o pulso da pilula - passa a valer widgets.raise_without_activation, que manda [NSWindow orderFront:] pela ponte de qt/mac.py; se a ponte falhar NAO caimos no raise_(), porque ficar um degrau abaixo no empilhamento e cosmetico e roubar o foco nao e.

Como a env vale para todo raise_(), as janelas que o usuario ABRE pela bandeja perderiam a vinda para a frente (activateWindow sozinho e makeKeyWindow, que nao ativa um app inativo no mac). Elas passam a chamar widgets.bring_to_front, que faz a ativacao explicita - mesma intencao de antes, agora so quando e do usuario.

Verificado com a pilula de verdade em cocoa real, largando o foco com [NSApp deactivate] e medindo por lsappinfo front + applicationStateChanged: o comportamento antigo se reativou sozinho 5x e ficou com o foco em 24 das 25 amostras; o atual, 0 e 0. Contraprova no mesmo teste: a pilula segue visivel, com NSWindow level 8 (acima das janelas normais), e bring_to_front continua trazendo uma janela normal para a frente.

Os testes novos falham se qualquer caminho AUTOMATICO da pilula voltar a chamar raise_().